### PR TITLE
chore(tooling): bring jq under mise; redis-cli via compose exec

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "22"
 pnpm = "11.1.1"
+"aqua:jqlang/jq" = "1.8.1"
 "aqua:nektos/act" = "0.2.88"
 "aqua:aquasecurity/trivy" = "0.70.0"
 "aqua:gitleaks/gitleaks" = "8.30.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,8 @@ Pinned in `.mise.toml` and Renovate-tracked:
 
 - **Node**: 22 (used by Renovate validation)
 - **pnpm**: 11.1.1
-- **act**: 0.2.87 (`aqua:nektos/act`)
+- **jq**: 1.8.1 (`aqua:jqlang/jq`)
+- **act**: 0.2.88 (`aqua:nektos/act`)
 - **trivy**: 0.70.0 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
 - **mermaid-cli**: 11.14.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)

--- a/Makefile
+++ b/Makefile
@@ -197,17 +197,17 @@ dapr-counter:
 dapr-get:
 	@curl -s -X GET "http://$(APP_HOST):$(HOST_PORT)/" -H "Content-Type: application/json" | jq .
 
-#redis-pending: @ Show pending Redis stream messages
+#redis-pending: @ Show pending Redis stream messages (via compose-running container)
 redis-pending:
-	@redis-cli XRANGE $(TOPIC_NAME) - +
+	@$(DOCKER_COMPOSE) exec -T redis redis-cli XRANGE $(TOPIC_NAME) - +
 
-#redis-clear: @ Clear Redis stream messages
+#redis-clear: @ Clear Redis stream messages (via compose-running container)
 redis-clear:
-	@redis-cli XTRIM $(TOPIC_NAME) MAXLEN = 0
+	@$(DOCKER_COMPOSE) exec -T redis redis-cli XTRIM $(TOPIC_NAME) MAXLEN = 0
 
-#redis-monitor: @ Monitor Redis commands
+#redis-monitor: @ Monitor Redis commands (via compose-running container)
 redis-monitor:
-	@redis-cli MONITOR
+	@$(DOCKER_COMPOSE) exec redis redis-cli MONITOR
 
 #release: @ Create and push a new tag
 release:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Dapr on Docker Compose — C# Queue Processor
 
-**Runtime surface:** ASP.NET Core minimal-API subscriber wired to a Dapr sidecar (`Dapr.AspNetCore`) for pub/sub on Redis Streams via `MapSubscribeHandler` + CloudEvents and Dapr state on Redis, with `OpenTelemetry.Extensions.Hosting` exporting OTLP traces to Jaeger and an `AddHealthChecks()`-backed `/healthz` endpoint probed by both the Dockerfile HEALTHCHECK and a compose-level healthcheck. **Delivery surface:** three-layer test pyramid (TUnit + FakeItEasy unit · TUnit + Testcontainers Redis+daprd integration · bash/curl e2e through Docker Compose covering pub/sub roundtrip and Jaeger trace ingestion), composite `make static-check` (`dotnet format --verify-no-changes` · `-warnaserror` · NuGet `--vulnerable` audit · Trivy filesystem scan · gitleaks · `minlag/mermaid-cli` C4 diagram lint), multi-stage production Dockerfile (non-root `app:app`, BuildKit-ARG-tunable HEALTHCHECK), GitHub Actions CI with `dorny/paths-filter` changes detector + `ci-pass` aggregator + `jdx/mise-action` toolchain bootstrap, `.env.example`-driven parameter externalization, mise-pinned auxiliary toolchain (Node, pnpm, act, trivy, gitleaks), and Renovate-managed deps with `automergeType: pr` covering NuGet + Dockerfile + docker-compose + GitHub Actions + mise + custom-regex (Makefile + C# annotations).
+**Runtime surface:** ASP.NET Core minimal-API subscriber wired to a Dapr sidecar (`Dapr.AspNetCore`) for pub/sub on Redis Streams via `MapSubscribeHandler` + CloudEvents and Dapr state on Redis, with `OpenTelemetry.Extensions.Hosting` exporting OTLP traces to Jaeger and an `AddHealthChecks()`-backed `/healthz` endpoint probed by both the Dockerfile HEALTHCHECK and a compose-level healthcheck. **Delivery surface:** three-layer test pyramid (TUnit + FakeItEasy unit · TUnit + Testcontainers Redis+daprd integration · bash/curl e2e through Docker Compose covering pub/sub roundtrip and Jaeger trace ingestion), composite `make static-check` (`dotnet format --verify-no-changes` · `-warnaserror` · NuGet `--vulnerable` audit · Trivy filesystem scan · gitleaks · `minlag/mermaid-cli` C4 diagram lint), multi-stage production Dockerfile (non-root `app:app`, BuildKit-ARG-tunable HEALTHCHECK), GitHub Actions CI with `dorny/paths-filter` changes detector + `ci-pass` aggregator + `jdx/mise-action` toolchain bootstrap, `.env.example`-driven parameter externalization, mise-pinned auxiliary toolchain (Node, pnpm, jq, act, trivy, gitleaks), and Renovate-managed deps with `automergeType: pr` covering NuGet + Dockerfile + docker-compose + GitHub Actions + mise + custom-regex (Makefile + C# annotations).
 
 ## Tech Stack
 
@@ -154,9 +154,9 @@ Run `make help` to see all targets.
 
 | Target | Description |
 |--------|-------------|
-| `make redis-pending` | Show pending Redis stream messages |
-| `make redis-clear` | Clear Redis stream messages |
-| `make redis-monitor` | Monitor Redis commands |
+| `make redis-pending` | Show pending Redis stream messages (via compose-running container) |
+| `make redis-clear` | Clear Redis stream messages (via compose-running container) |
+| `make redis-monitor` | Monitor Redis commands (via compose-running container) |
 
 ### CI & Utilities
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ make dapr-pub   # publish a test message
 | [Git](https://git-scm.com/) | 2.0+ | Version control |
 | [.NET SDK](https://dotnet.microsoft.com/download) | 10.0 | C# runtime and compiler (pinned in `global.json`) |
 | [Docker](https://www.docker.com/) | latest | Container runtime with Compose v2 |
-| [mise](https://mise.jdx.dev/) | latest | Polyglot version manager (Node, pnpm, act per `.mise.toml`) |
-| [jq](https://jqlang.github.io/jq/) | latest | API response formatting |
-| [redis-cli](https://redis.io/docs/getting-started/) | latest | Redis debugging (optional) |
+| [mise](https://mise.jdx.dev/) | latest | Polyglot version manager (Node, pnpm, jq, act, trivy, gitleaks per `.mise.toml`) |
+| [jq](https://jqlang.github.io/jq/) | 1.8.x | API response formatting (auto-installed by `make deps` via mise) |
 
 Install required tools (idempotent — verifies .NET / Docker, bootstraps mise, installs `.mise.toml` tools):
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/dapr-docker-csharp)
 
-# Dapr on Docker Compose — C# Queue Processor
+# Production-Pattern C# Microservice on Dapr + Docker Compose
 
 **Runtime surface:** ASP.NET Core minimal-API subscriber wired to a Dapr sidecar (`Dapr.AspNetCore`) for pub/sub on Redis Streams via `MapSubscribeHandler` + CloudEvents and Dapr state on Redis, with `OpenTelemetry.Extensions.Hosting` exporting OTLP traces to Jaeger and an `AddHealthChecks()`-backed `/healthz` endpoint probed by both the Dockerfile HEALTHCHECK and a compose-level healthcheck. **Delivery surface:** three-layer test pyramid (TUnit + FakeItEasy unit · TUnit + Testcontainers Redis+daprd integration · bash/curl e2e through Docker Compose covering pub/sub roundtrip and Jaeger trace ingestion), composite `make static-check` (`dotnet format --verify-no-changes` · `-warnaserror` · NuGet `--vulnerable` audit · Trivy filesystem scan · gitleaks · `minlag/mermaid-cli` C4 diagram lint), multi-stage production Dockerfile (non-root `app:app`, BuildKit-ARG-tunable HEALTHCHECK), GitHub Actions CI with `dorny/paths-filter` changes detector + `ci-pass` aggregator + `jdx/mise-action` toolchain bootstrap, `.env.example`-driven parameter externalization, mise-pinned auxiliary toolchain (Node, pnpm, jq, act, trivy, gitleaks), and Renovate-managed deps with `automergeType: pr` covering NuGet + Dockerfile + docker-compose + GitHub Actions + mise + custom-regex (Makefile + C# annotations).
 


### PR DESCRIPTION
## Summary

- **jq** is now mise-managed via `aqua:jqlang/jq = "1.8.1"` in `.mise.toml`. `make deps` auto-installs it on fresh checkouts; the native `mise` Renovate manager tracks updates.
- **redis-cli** is no longer a host-side dependency. The three `make redis-*` targets now run inside the compose-running `redis` container via `$(DOCKER_COMPOSE) exec -T redis redis-cli …`. The targets only made sense when the compose stack was running anyway (they connected to `localhost:6379`, the compose-exposed port), so this removes a host dependency without losing functionality.

The mise alternative for redis-cli is the `asdf:mise-plugins/mise-redis` plugin which compiles full Redis from source — a heavy first-time install just for the CLI. The compose-exec path is cleaner when the compose stack is already a project prerequisite.

## Test plan

- [x] `mise install` resolves jq to `~/.local/share/mise/installs/aqua-jqlang-jq/1.8.1/jq`
- [x] `make redis-pending` against a running compose stack returns clean (empty stream output)
- [x] `make redis-clear` returns `0` (XTRIM result)
- [x] `make help` shows the three updated target descriptions
- [x] README Prerequisites no longer lists redis-cli; jq row notes the mise auto-install
- [x] CLAUDE.md Tool Versions includes `jq: 1.8.1 (aqua:jqlang/jq)`