### PR TITLE
fix(ci): mise-action on every mise-using job + GITHUB_TOKEN forwarding for act

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
+
       - name: Build
         run: make build
 
@@ -97,6 +102,11 @@ jobs:
           global-json-file: global.json
           cache: true
           cache-dependency-path: '**/packages.lock.json'
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
 
       - name: Test
         run: make test
@@ -114,6 +124,11 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
+
       - name: Integration test
         run: make integration-test
 
@@ -129,6 +144,11 @@ jobs:
           global-json-file: global.json
           cache: true
           cache-dependency-path: '**/packages.lock.json'
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
 
       - name: E2E (Docker Compose)
         run: make e2e

--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,17 @@ ci: deps static-check test integration-test build
 #ci-run: @ Run GitHub Actions workflow locally using act
 ci-run: deps-act
 	@docker container prune -f >/dev/null 2>&1 || true
-	@ACT_PORT=$$(shuf -i $(ACT_PORT_MIN)-$(ACT_PORT_MAX) -n 1); \
+	@# Forward GITHUB_TOKEN env-only (per security rule: never put secret VALUES on argv).
+	@# act --secret KEY reads VALUE from inherited env. Auto-derive from gh CLI when unset.
+	@if [ -z "$$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1; then \
+		export GITHUB_TOKEN="$$(gh auth token 2>/dev/null)"; \
+	fi; \
+	ACT_PORT=$$(shuf -i $(ACT_PORT_MIN)-$(ACT_PORT_MAX) -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d); \
-	for j in static-check build test integration-test ci-pass; do \
+	for j in static-check build test integration-test e2e ci-pass; do \
 		echo "==> act job: $$j"; \
 		act push --job "$$j" --container-architecture linux/amd64 --pull=false \
+			--secret GITHUB_TOKEN \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" || exit $$?; \
 	done


### PR DESCRIPTION
## Summary

Surfaced by `/ship-it` Stage 3 (`make ci-run`). Three real bugs in the post-PR-#30 state:

1. **`build` / `test` / `integration-test` / `e2e` jobs missing `jdx/mise-action`** — they call `make <X>` → `make deps` → `mise install`. Without their own mise-action they relied on the `static-check` job's GHA cross-job cache for the `mise install` to be a no-op. That works on real GHA but breaks under `act` (no cache).
2. **`make ci-run` loop omitted `e2e`** — the job ran transitively via `ci-pass`'s `needs:` chain, masking the loop bug. Fix: add `e2e` to the loop so it runs as its own per-job invocation per the `/makefile` skill "Local CI with act" rule.
3. **`make ci-run` didn't forward `GITHUB_TOKEN` to act** — act runs in a clean env; mise-action without a token still rate-limits. Fix: `--secret GITHUB_TOKEN` (env-only form per security rule), auto-derived from `gh auth token` when the env var is unset.

## Test plan

- [x] `make ci-run` exit 0; all 6 jobs (static-check, build, test, integration-test, e2e, ci-pass) green under act
- [x] e2e: 9/9 PASS (health, state roundtrip, pub/sub delivery, negative case, Jaeger trace ingestion)
- [x] `actionlint` exit 0
- [x] `make ci` (without act) exit 0, 6 unit + 4 integration tests pass