### PR TITLE
chore: bump .NET SDK 10.0.201 → 10.0.203

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@
 
 | Component | Technology |
 |-----------|------------|
-| Language | C# / .NET 10.0 (SDK 10.0.201 via `global.json`) |
-| Framework | ASP.NET Core (`Microsoft.NET.Sdk.Web`), `Dapr.AspNetCore` |
+| Language | C# / .NET 10.0 LTS (SDK 10.0.203 via `global.json`, `rollForward: latestFeature`) |
+| Framework | ASP.NET Core (`Microsoft.NET.Sdk.Web`), `Dapr.AspNetCore` 1.17 |
 | Messaging | Dapr pub/sub on Redis Streams |
 | State store | Dapr state on Redis |
-| Tracing | OpenTelemetry → Jaeger (compose-declared) |
-| Unit / integration testing | TUnit 1.28.0 + `WebApplicationFactory` + Testcontainers 4.11 |
-| Mocking | FakeItEasy 9.0.1 |
-| E2E testing | Docker Compose + bash curl harness |
-| Container runtime | Docker Compose v2 |
+| Tracing | OpenTelemetry → Jaeger via `OpenTelemetry.Extensions.Hosting` 1.15 (OTLP gRPC) |
+| Unit / integration testing | TUnit 1.44 + `WebApplicationFactory` + Testcontainers 4.11 (Redis + daprd) |
+| Mocking | FakeItEasy 9.0 |
+| E2E testing | Docker Compose + bash curl harness + Dapr publish API |
+| Container runtime | Docker Compose v2; production multi-stage `src/queue-processor/Dockerfile` (non-root `app:app`, BuildKit-ARG HEALTHCHECK) |
 | Static analysis | `dotnet format`, `dotnet build -warnaserror`, `dotnet list package --vulnerable`, Trivy filesystem scan, gitleaks, mermaid-cli |
-| CI | GitHub Actions (changes → static-check → build/test/integration-test → e2e → ci-pass) |
-| Dependency mgmt | Renovate (PR automerge, squash) |
-| Version manager | mise (`.mise.toml` pins Node, pnpm, act, trivy, gitleaks) |
+| CI | GitHub Actions (changes → static-check → build/test/integration-test → e2e → ci-pass), `dorny/paths-filter` + `jdx/mise-action` |
+| Dependency mgmt | Renovate (`automergeType: pr`, squash) — covers NuGet + Dockerfile + docker-compose + GitHub Actions + mise + custom-regex |
+| Version manager | mise (`.mise.toml` pins Node, pnpm, jq, act, trivy, gitleaks) |
 
 ## Quick Start
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.203",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary

Two servicing patches published to the .NET 10 LTS channel feed:
- 10.0.202 (2026-03-25)
- **10.0.203** (2026-04-21)

The earlier `/upgrade-analysis` run this session missed them because it was probing `gh api repos/dotnet/sdk/releases/latest` and `git/refs/tags`. Both lie about the latest .NET SDK — servicing patches ship to the channel feed without a matching GitHub release entry or tag in `dotnet/sdk`. Authoritative source is Microsoft's channel feed (`https://dotnetcli.blob.core.windows.net/dotnet/Sdk/10.0/latest.version`).

Skill fix already pushed to claude-config (`d07c72a`):
- `/upgrade-analysis` — new `.NET SDK channel-feed rule` section with broken-vs-correct sources table.
- `/renovate` — clarifying note that the `nuget` manager's `dotnet-version` datasource for `global.json` IS authoritative; when the two skills disagree, Renovate wins.

## Test plan

- [x] `make build` — exit 0, 0 warnings
- [x] `dotnet --version` resolves to 10.0.203 (via `rollForward: latestFeature` + locally installed SDK)
- [x] Channel-feed `curl` confirms 10.0.203 is current head