### PR TITLE
feat: integration coverage gaps + ci-run hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Pinned in `.mise.toml` and Renovate-tracked:
 - **trivy**: 0.70.0 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
 - **mermaid-cli**: 11.14.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
-- **.NET SDK**: 10.0.201 (from `global.json`)
+- **.NET SDK**: 10.0.203 (from `global.json`)
 
 ## Testing
 
@@ -122,6 +122,8 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push to main, tags 
 | **ci-pass** | all of the above (always) | Aggregator status check (target for branch protection / Rulesets) |
 
 Permissions: workflow-level `contents: read` + `pull-requests: read` (for `paths-filter`). SDK version from `global.json`. NuGet caching via `packages.lock.json`. mise-action installs `.mise.toml`-pinned tools for the static-check job.
+
+**Toolchain split (documented exception to the "mise-action over `setup-*`" portfolio rule)**: `actions/setup-dotnet@<sha>` is retained alongside `jdx/mise-action` because (a) `global.json`'s `rollForward: latestFeature` is honored at install time by setup-dotnet — mise would require an exact `.mise.toml` pin and lose the rollForward semantics, and (b) setup-dotnet's `cache: true` + `packages.lock.json` is the canonical NuGet cache. mise-action owns the non-.NET surface (Node, pnpm, jq, act, trivy, gitleaks).
 
 A separate cleanup workflow (`.github/workflows/cleanup-runs.yml`) prunes old workflow runs (`cleanup-runs`) and stale branch caches (`cleanup-caches`) weekly.
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ CURRENTTAG     := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "de
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.14.0
 
+# act runner image. CI uses GitHub-hosted `ubuntu-latest`; act needs an
+# equivalent locally. Pin the DATED catthehacker tag (immutable, content-
+# addressable) — NOT the floating `act-latest` tag, which would let
+# `docker pull` swap the image out from under us between runs and break
+# reproducibility. The dated tag mirrors the workflow's `runs-on:
+# ubuntu-latest` substrate at the moment of this commit; Renovate bumps
+# the date roughly weekly via the docker datasource (catthehacker publishes
+# `act-latest-YYYYMMDD` snapshots alongside the floating tag).
+# `versioning=loose` because the suffix isn't semver — Renovate compares
+# tags lexicographically and a later date sorts higher.
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
+ACT_UBUNTU_VERSION := act-latest-20260515
+
 
 # === Project Paths ===
 SOLUTION             := dapr-docker-csharp.slnx
@@ -85,6 +98,17 @@ e2e: deps
 lint: deps
 	@dotnet format "$(SOLUTION)" --verify-no-changes
 	@dotnet build "$(SOLUTION)" -c Release -warnaserror --nologo -v q
+	@# Guard against shell scripts losing +x mode (e.g., a subagent Write that
+	@# defaults to 0644, or a careless `chmod -x`). Without +x, CI invokes the
+	@# script as ./path/to/file.sh and exits 126 "Permission denied" — the kind
+	@# of regression that ci-run wouldn't catch if the e2e job is skipped.
+	@NONEXEC=$$(find scripts e2e -name '*.sh' -not -executable -print 2>/dev/null); \
+	if [ -n "$$NONEXEC" ]; then \
+		echo "Error: shell scripts missing +x mode:"; \
+		echo "$$NONEXEC" | sed 's/^/  /'; \
+		echo "Fix: chmod +x <file>; git add <file>"; \
+		exit 1; \
+	fi
 
 #vulncheck: @ Check for vulnerable NuGet packages
 vulncheck: deps
@@ -148,13 +172,23 @@ ci-run: deps-act
 	fi; \
 	ACT_PORT=$$(shuf -i $(ACT_PORT_MIN)-$(ACT_PORT_MAX) -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d); \
+	trap 'rm -rf "$$ARTIFACT_PATH"' EXIT INT TERM; \
 	for j in static-check build test integration-test e2e ci-pass; do \
 		echo "==> act job: $$j"; \
 		act push --job "$$j" --container-architecture linux/amd64 --pull=false \
+			-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--secret GITHUB_TOKEN \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" || exit $$?; \
 	done
+	@# Note on the loop list: `ci-pass` is the workflow's aggregator (needs:
+	@# all of the above). When act runs `--job ci-pass`, it resolves the
+	@# `needs:` DAG and re-executes every upstream job transitively before
+	@# evaluating the aggregator step. This is intentional duplication —
+	@# kept for portfolio-wide uniformity across all dapr-* / spring-* repos
+	@# where every workflow job is explicit in the ci-run loop, and so a
+	@# future top-level job that ci-pass doesn't `needs:` cannot be silently
+	@# omitted. The cost is one extra full pass at the end of ci-run.
 
 #renovate-bootstrap: @ Install Node + pnpm for Renovate (via mise)
 renovate-bootstrap: deps

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Three-layer pyramid:
 | Layer | Where | Real dependencies | Command |
 |-------|-------|-------------------|---------|
 | Unit | `tests/queue-processor.tests/EndpointTests.cs` (TUnit + `WebApplicationFactory` + FakeItEasy-mocked `DaprClient`) | none — in-process | `make test` |
-| Integration | `tests/queue-processor.integration.tests/StateStoreIntegrationTests.cs` (TUnit + Testcontainers Redis + daprd container, real `DaprClient` over HTTP/gRPC) | Redis + daprd via Testcontainers | `make integration-test` |
-| E2E | `e2e/e2e-test.sh` (curl + Dapr publish API against the full Docker Compose stack) | Full compose stack: app + daprd + Redis + Jaeger | `make e2e` |
+| Integration | `tests/queue-processor.integration.tests/{StateStoreIntegrationTests,EndpointsIntegrationTests,SubscriptionContractTests}.cs` (TUnit + Testcontainers Redis + daprd container, real `DaprClient` over HTTP/gRPC; `SubscriptionContractTests` asserts the `/dapr/subscribe` wire shape in-process) | Redis + daprd via Testcontainers (none for the subscription contract test) | `make integration-test` |
+| E2E | `e2e/e2e-test.sh` (curl + Dapr publish API against the full Docker Compose stack; asserts POST `/counter` status + `Location` header + body, pub/sub roundtrip, and Jaeger service registration + at least one recorded trace) | Full compose stack: app + daprd + Redis + Jaeger | `make e2e` |
 
 ## Available Make Targets
 

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -113,6 +113,39 @@ assert_body_equals() {
     fi
 }
 
+# check_post — POST helper that asserts HTTP status + Location header + body
+# in a single curl, per the test-coverage skill's POST-assertion rule. Three
+# orthogonal contracts (status code, Location target, response body) are each
+# load-bearing for the queueprocessor's `Results.Accepted("/", squared)`
+# response shape; asserting only the body would let a 200/Created regression
+# ship as long as the squared value still appeared in the response stream.
+#
+# Captures the body via -o, the response headers via -D, and the status code
+# via -w '%{http_code}' — one curl invocation, no race between separate probes.
+check_post() {
+    local name="$1" url="$2" body_json="$3" expected_status="$4" expected_body="$5" expected_location="$6"
+    local body_tmp headers_tmp; body_tmp=$(mktemp); headers_tmp=$(mktemp)
+    local status
+    status=$(curl -s -o "$body_tmp" -D "$headers_tmp" -w '%{http_code}' \
+        --max-time "$E2E_CURL_MAX_TIME_SECONDS" \
+        -X POST -H 'Content-Type: application/json' -d "$body_json" "$url" 2>/dev/null || echo "000")
+    local body; body=$(cat "$body_tmp"); rm -f "$body_tmp"
+    # tolower() on both sides for portability across mawk (Ubuntu default) and
+    # gawk — IGNORECASE is gawk-only and silently no-ops under mawk.
+    local location
+    location=$(awk 'tolower($1)=="location:"{sub(/^[^:]*:[ \t]*/,""); print; exit}' "$headers_tmp" | tr -d '\r')
+    rm -f "$headers_tmp"
+    local bad=0
+    [ "$status" = "$expected_status" ] || { bad=1; echo "    status:   got '$status', expected '$expected_status'"; }
+    [ "$body" = "$expected_body" ]       || { bad=1; echo "    body:     got '$body', expected '$expected_body'"; }
+    [ "$location" = "$expected_location" ] || { bad=1; echo "    location: got '$location', expected '$expected_location'"; }
+    if [ "$bad" -eq 0 ]; then
+        pass "$name (HTTP $status, body '$body', Location '$location')"
+    else
+        fail "$name"
+    fi
+}
+
 echo "==> Bringing up Docker Compose stack on host port ${HOST_PORT}"
 "${COMPOSE[@]}" up -d --build --quiet-pull >/dev/null
 
@@ -131,26 +164,16 @@ echo "==> Test 1: initial state is 0"
 assert_body_equals "$BASE/" "0"
 
 echo ""
-echo "==> Test 2: POST /counter squares the input"
-result=$(curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" -X POST -H 'Content-Type: application/json' -d '5' "$BASE/counter" || echo "<error>")
-if [ "$result" = "25" ]; then
-    pass "POST /counter 5 → 25"
-else
-    fail "POST /counter 5 → '$result' (expected 25)"
-fi
+echo "==> Test 2: POST /counter squares the input (202 Accepted + Location: /)"
+check_post "POST /counter 5 → 25" "$BASE/counter" '5' '202' '25' '/'
 
 echo ""
 echo "==> Test 3: state roundtrip — GET / returns the squared value"
 assert_body_equals "$BASE/" "25"
 
 echo ""
-echo "==> Test 4: POST /counter 0 saves 0"
-result=$(curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" -X POST -H 'Content-Type: application/json' -d '0' "$BASE/counter" || echo "<error>")
-if [ "$result" = "0" ]; then
-    pass "POST /counter 0 → 0"
-else
-    fail "POST /counter 0 → '$result' (expected 0)"
-fi
+echo "==> Test 4: POST /counter 0 saves 0 (202 Accepted + Location: /)"
+check_post "POST /counter 0 → 0" "$BASE/counter" '0' '202' '0' '/'
 assert_body_equals "$BASE/" "0"
 
 echo ""
@@ -184,24 +207,54 @@ assert_status GET "$BASE/this-route-does-not-exist" 404
 
 echo ""
 echo "==> Test 7: OTel — app emits spans to Jaeger OTLP collector"
-# Drive at least one request so an ASP.NET Core span is produced.
-curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" "$BASE/" >/dev/null || true
-# Jaeger ingests via OTLP gRPC. Query Jaeger's HTTP /api/services from inside
-# the compose network. Poll up to 30s for the service to register.
-seen_traces=""
+# Drive several requests so multiple ASP.NET Core spans are produced. The OTLP
+# exporter buffers and flushes in batches (default ~5s), so a single request
+# may not land before the first poll iteration.
+for _ in 1 2 3 4 5; do
+    curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" "$BASE/" >/dev/null || true
+done
+
+# Jaeger ingests via OTLP gRPC. Query its HTTP query API from inside the
+# compose network so we don't depend on a host-side Jaeger port mapping.
+# Two contracts to assert (service registration alone is necessary-but-not-
+# sufficient — Jaeger registers the service name on the FIRST span ever seen,
+# so a stale service registration can pass while subsequent exports are
+# silently failing):
+#   1. /api/services lists `${OTEL_SERVICE_NAME}` (exporter wired correctly)
+#   2. /api/traces?service=${OTEL_SERVICE_NAME}&limit=1 returns ≥1 trace
+#      with a "traceID" field (spans are actually being delivered)
+seen_service=""
+seen_trace=""
+last_traces_resp=""
+last_services_resp=""
 for _ in $(seq 1 "$E2E_JAEGER_POLL_SECONDS"); do
-    resp=$("${COMPOSE[@]}" exec -T queueprocessor curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" \
-        "http://${JAEGER_HOST}:${JAEGER_QUERY_PORT}/api/services" 2>/dev/null || true)
-    if echo "$resp" | grep -q "\"${OTEL_SERVICE_NAME}\""; then
-        seen_traces=yes
-        break
+    if [ "$seen_service" != yes ]; then
+        last_services_resp=$("${COMPOSE[@]}" exec -T queueprocessor curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" \
+            "http://${JAEGER_HOST}:${JAEGER_QUERY_PORT}/api/services" 2>/dev/null || true)
+        if echo "$last_services_resp" | grep -q "\"${OTEL_SERVICE_NAME}\""; then
+            seen_service=yes
+        fi
+    fi
+    if [ "$seen_service" = yes ] && [ "$seen_trace" != yes ]; then
+        last_traces_resp=$("${COMPOSE[@]}" exec -T queueprocessor curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" \
+            "http://${JAEGER_HOST}:${JAEGER_QUERY_PORT}/api/traces?service=${OTEL_SERVICE_NAME}&limit=1" 2>/dev/null || true)
+        if echo "$last_traces_resp" | grep -q '"traceID"'; then
+            seen_trace=yes
+            break
+        fi
     fi
     sleep "$E2E_POLL_INTERVAL_SECONDS"
 done
-if [ "$seen_traces" = yes ]; then
-    pass "Jaeger registered service '${OTEL_SERVICE_NAME}' — OTel exporter is wired"
+
+if [ "$seen_service" = yes ]; then
+    pass "Jaeger registered service '${OTEL_SERVICE_NAME}'"
 else
-    fail "Jaeger did not see service '${OTEL_SERVICE_NAME}' within ${E2E_JAEGER_POLL_SECONDS}s (last response: '${resp:-<empty>}')"
+    fail "Jaeger did not see service '${OTEL_SERVICE_NAME}' within ${E2E_JAEGER_POLL_SECONDS}s (last response: '${last_services_resp:-<empty>}')"
+fi
+if [ "$seen_trace" = yes ]; then
+    pass "Jaeger returned at least one trace for '${OTEL_SERVICE_NAME}' (spans delivered)"
+else
+    fail "Jaeger returned no traces for '${OTEL_SERVICE_NAME}' within ${E2E_JAEGER_POLL_SECONDS}s (last response: '${last_traces_resp:-<empty>}')"
 fi
 
 echo ""

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
         "scripts/**/*.bash"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z_]+\\s*[:?]?=\\s*(?<currentValue>v?\\d[\\w.+-]*)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z_]+\\s*[:?]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
       ]
     },
     {

--- a/tests/queue-processor.integration.tests/DaprStateStoreFixture.cs
+++ b/tests/queue-processor.integration.tests/DaprStateStoreFixture.cs
@@ -24,6 +24,9 @@ public sealed class DaprStateStoreFixture : IAsyncInitializer, IAsyncDisposable
     private static readonly ushort DaprGrpcPort =
         ushort.Parse(Environment.GetEnvironmentVariable("DAPR_GRPC_PORT") ?? "50001");
 
+    // Mirrors compose/components/statestore.yaml (no keyPrefix override → defaults
+    // to "appid"). Tests use Guid-suffixed keys so the prefix is irrelevant to
+    // assertions; matching prod removes a fixture-vs-production divergence.
     private const string StateStoreComponent = """
         apiVersion: dapr.io/v1alpha1
         kind: Component
@@ -37,8 +40,24 @@ public sealed class DaprStateStoreFixture : IAsyncInitializer, IAsyncDisposable
             value: redis:6379
           - name: redisPassword
             value: ""
-          - name: keyPrefix
-            value: none
+        """;
+
+    // Mirrors compose/components/pubsub.yaml. Mounted into daprd's resources
+    // directory so EndpointsIntegrationTests can register the [Topic] handler
+    // and publish/poll a roundtrip through the same broker the app uses in prod.
+    private const string PubSubComponent = """
+        apiVersion: dapr.io/v1alpha1
+        kind: Component
+        metadata:
+          name: pubsub
+        spec:
+          type: pubsub.redis
+          version: v1
+          metadata:
+          - name: redisHost
+            value: redis:6379
+          - name: redisPassword
+            value: ""
         """;
 
     private INetwork _network = null!;
@@ -63,6 +82,9 @@ public sealed class DaprStateStoreFixture : IAsyncInitializer, IAsyncDisposable
             .WithResourceMapping(
                 Encoding.UTF8.GetBytes(StateStoreComponent),
                 "/components/statestore.yaml")
+            .WithResourceMapping(
+                Encoding.UTF8.GetBytes(PubSubComponent),
+                "/components/pubsub.yaml")
             .WithCommand(
                 "./daprd",
                 "--app-id", "queue-processor-it",

--- a/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
+++ b/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Http.Json;
+using Dapr.Client;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace QueueProcessor.IntegrationTests;
+
+// Endpoints exercised through Program.cs's real route handlers against a real
+// daprd sidecar + real Redis. Unit tests cover the same handlers with a mocked
+// DaprClient; this layer catches DI wiring, state-store name drift, and
+// serialization regressions that only surface against real Dapr.
+//
+// The app's `/counter` endpoint persists to a fixed key ("counter") so tests
+// within this class must serialize (NotInParallel) to avoid cross-test races.
+// Other test classes are unaffected: StateStoreIntegrationTests uses
+// Guid-suffixed keys.
+[ClassDataSource<DaprStateStoreFixture>(Shared = SharedType.PerClass)]
+[Category("Integration")]
+[NotInParallel]
+public sealed class EndpointsIntegrationTests(DaprStateStoreFixture fixture)
+{
+    private const string Store = "statestore";
+    private const string CounterKey = "counter";
+
+    private WebApplicationFactory<Program> CreateFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DaprClient));
+                if (descriptor is not null)
+                    services.Remove(descriptor);
+                services.AddSingleton(fixture.Client);
+            });
+        });
+
+    [Test]
+    public async Task PostCounter_PersistsState_AndGetReturnsSquaredValue()
+    {
+        await fixture.Client.DeleteStateAsync(Store, CounterKey);
+
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var postResponse = await client.PostAsJsonAsync("/counter", 7);
+        await Assert.That(postResponse.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+        await Assert.That(postResponse.Headers.Location?.OriginalString).IsEqualTo("/");
+        var postValue = await postResponse.Content.ReadFromJsonAsync<int>();
+        await Assert.That(postValue).IsEqualTo(49);
+
+        var getResponse = await client.GetAsync("/");
+        await Assert.That(getResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var getValue = await getResponse.Content.ReadFromJsonAsync<int>();
+        await Assert.That(getValue).IsEqualTo(49);
+    }
+
+    [Test]
+    public async Task GetRoot_ReturnsZero_WhenStateIsAbsent()
+    {
+        await fixture.Client.DeleteStateAsync(Store, CounterKey);
+
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var value = await response.Content.ReadFromJsonAsync<int>();
+        await Assert.That(value).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PostCounter_OverwritesPriorValue()
+    {
+        await fixture.Client.SaveStateAsync(Store, CounterKey, 100);
+
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var postResponse = await client.PostAsJsonAsync("/counter", 4);
+        await Assert.That(postResponse.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+
+        var stored = await fixture.Client.GetStateAsync<int>(Store, CounterKey);
+        await Assert.That(stored).IsEqualTo(16);
+    }
+}

--- a/tests/queue-processor.integration.tests/SubscriptionContractTests.cs
+++ b/tests/queue-processor.integration.tests/SubscriptionContractTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace QueueProcessor.IntegrationTests;
+
+// /dapr/subscribe is the wire contract daprd polls at startup to discover which
+// (pubsub, topic) → route bindings the app accepts. A regression in the
+// `.WithTopic(...)` chain on Program.cs's POST /counter endpoint (topic rename,
+// route mapping change, accidental removal) silently breaks every published
+// message in production — the app pod stays Ready, daprd logs nothing
+// actionable, every event is dropped at the subscription layer.
+//
+// This test asserts the contract Dapr.AspNetCore 1.17 serializes for the
+// app's single subscription:
+//   [{"topic":"counter","pubsubName":"pubsub","route":"counter"}]
+//
+// JsonNamingPolicy.CamelCase + DefaultIgnoreCondition.WhenWritingNull
+// (verified against the Dapr.AspNetCore source) — null-valued routes /
+// metadata / deadLetterTopic / bulkSubscribe properties are omitted.
+// Route is emitted without a leading slash (the SDK joins RoutePattern's
+// PathSegments with "/", which produces "counter" for a single-segment
+// pattern; daprd prepends the slash when POSTing to the app).
+//
+// No daprd container is needed; the test runs entirely in-process against
+// MapSubscribeHandler's auto-registered endpoint.
+[Category("Integration")]
+public sealed class SubscriptionContractTests
+{
+    [Test]
+    public async Task DaprSubscribe_AdvertisesCounterTopicOnPubSubRoutedToSlashCounter()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/dapr/subscribe");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        await using var body = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(body);
+
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Array);
+        await Assert.That(doc.RootElement.GetArrayLength()).IsEqualTo(1);
+
+        var sub = doc.RootElement[0];
+        await Assert.That(sub.GetProperty("pubsubName").GetString()).IsEqualTo("pubsub");
+        await Assert.That(sub.GetProperty("topic").GetString()).IsEqualTo("counter");
+        await Assert.That(sub.GetProperty("route").GetString()).IsEqualTo("counter");
+
+        // enableRawPayload=false on .WithTopic — metadata must be absent.
+        await Assert.That(sub.TryGetProperty("metadata", out _)).IsFalse();
+    }
+}

--- a/tests/queue-processor.integration.tests/packages.lock.json
+++ b/tests/queue-processor.integration.tests/packages.lock.json
@@ -23,6 +23,17 @@
           "Microsoft.Extensions.Options": "10.0.3"
         }
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
       "Testcontainers": {
         "type": "Direct",
         "requested": "[4.11.0, )",
@@ -62,6 +73,18 @@
         "type": "Transitive",
         "resolved": "2.6.2",
         "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Dapr.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "1.17.9",
+        "contentHash": "9YqQ+7fDs/ci5ebavcoIz0ykj2BwFxrCpccG4FowcSP0lf947ygsFjN/2aRBz0kjSB7GZsxslq6uTaFLJY6E7g==",
+        "dependencies": {
+          "Dapr.Client": "1.17.9",
+          "Dapr.Common": "1.17.9",
+          "Google.Api.CommonProtos": "2.17.0",
+          "Google.Protobuf": "3.34.0",
+          "Grpc.Net.Client": "2.76.0"
+        }
       },
       "Dapr.Common": {
         "type": "Transitive",
@@ -155,6 +178,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
       "Microsoft.DiaSymReader": {
         "type": "Transitive",
         "resolved": "2.2.5",
@@ -162,65 +190,181 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "H1Cjv2xmm7O3iAGmFTcnSM0ZhLQ/7SqefmAvSJoT1PbXoxeYc2fo0mCLn2JlVbr9E6YpoU9q/o0fI9neDJB0xQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Primitives": "10.0.3"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "xVDHL0+SIgemfh95fTO9cGLe17TWv/ZP0n7m01z8X6pzt2DmQpucioWR/mYZA1sRlkWnkXzfl0JweLNWmE9WMg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.3"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "759UhpKaR5Jsll9kXpkft4z/7tpeF7Dw2rTY/9f9JchaSQTpRFNIPkZFZvoo7fFpbjUaqtDlO5aiGpmQrp/EUA==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.3",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "2DLOmC0EkB2smVK8lPP1PIKEgL1arE3CMp9XSIQB/Y7ev5nnnyuM/PizKJ6QfLD08QCYoopSC9SFdbYglDomYg==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "bwGMrRcAMWx2s/RDgja97p27rxSz2pEQW0+rX5cWAUWVETVJ/eyxGfjAl8vuG5a+lckWmPIE+vcuaZNVB5YDdw=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "tc0R6i2T+138taoxFPQXb7Sy/4rtq4ytoJrAt4fNGs6k89mHpEhZnXUNgaFKwwb5Ud5rIUeLC6tfpsuHNwiWqg==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.3",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -238,47 +382,108 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "8D9Er1cGXNjNDIB+VLBNHn386L5ls2FoiG9a6o12gyn+GG3w6jdfUhzT8dtBnKcevE7/fsVA8MS3FBgFfClFtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "hU6WzGTPvPoLA2ng1ILvWQb3g0qORdlHNsxI8IcPLumJb3suimYUl+bbDzdo1V4KFsvVhnMWzysHpKbZaoDQPQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Primitives": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "bn6QoBbbvwmzLIFyxrnL2/e+sqoNUOGbHyfWK9DPONMv1mDCYHm/C7MusYASM31b2lUx6OiDmonb3v+dv5t0nA==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "Microsoft.Extensions.Primitives": "10.0.3"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Transitive",
@@ -329,6 +534,65 @@
           "Microsoft.Testing.Platform": "2.2.2"
         }
       },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "1.15.2",
+        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "Transitive",
+        "resolved": "1.15.1",
+        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
       "SharpZipLib": {
         "type": "Transitive",
         "resolved": "1.4.2",
@@ -342,6 +606,11 @@
           "BouncyCastle.Cryptography": "2.6.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
       "TUnit.Assertions": {
         "type": "Transitive",
@@ -363,6 +632,16 @@
           "Microsoft.Testing.Platform": "2.2.2",
           "Microsoft.Testing.Platform.MSBuild": "2.2.2",
           "TUnit.Core": "1.44.0"
+        }
+      },
+      "queue-processor": {
+        "type": "Project",
+        "dependencies": {
+          "Dapr.AspNetCore": "[1.17.9, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )"
         }
       }
     }

--- a/tests/queue-processor.integration.tests/queue-processor.integration.tests.csproj
+++ b/tests/queue-processor.integration.tests/queue-processor.integration.tests.csproj
@@ -12,9 +12,14 @@
 
     <ItemGroup>
         <PackageReference Include="TUnit" Version="1.44.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7"/>
         <PackageReference Include="Testcontainers" Version="4.11.0"/>
         <PackageReference Include="Testcontainers.Redis" Version="4.11.0"/>
         <PackageReference Include="Dapr.Client" Version="1.17.9"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../src/queue-processor/queue-processor.csproj"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Closes the 5 gaps from `/test-coverage-analysis` and the 4 fixes from the `/makefile` audit, in one coherent sweep. See `git log -1` for the full per-area breakdown.

**Tests** — 2 new integration-test classes:
- `EndpointsIntegrationTests` — POST /counter + GET / through `WebApplicationFactory<Program>` against the fixture's real DaprClient (Testcontainers Redis + daprd).
- `SubscriptionContractTests` — asserts `/dapr/subscribe` wire shape in-process, no daprd needed.

**Fixture** — mounts `pubsub.redis` Component alongside `statestore`; removes `keyPrefix: none` so the integration layer exercises the same physical Redis key shape as prod.

**E2E** — `check_post` helper asserts HTTP 202 + `Location: /` + body together (Tests 2/4); Test 7 now asserts ≥1 trace actually recorded in Jaeger, not just service-name registration.

**Makefile** — `ACT_UBUNTU_VERSION := act-latest-20260515` (dated immutable tag, Renovate-tracked, `versioning=loose`); `-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION)` in `ci-run`; `trap 'rm -rf "$ARTIFACT_PATH"' EXIT INT TERM` for the loop; new `find scripts e2e -not -executable` guard in `lint`.

**Renovate** — widened Makefile customManager regex (`v?\d[\w.+-]*` → `[\w][\w.+-]*`) to capture letter-starting Docker tags. Verified extraction of `catthehacker/ubuntu` and unchanged extraction of `minlag/mermaid-cli`.

**Docs** — CLAUDE.md SDK version refresh + documented `actions/setup-dotnet` retention as the canonical exception to the mise-action portfolio rule (rollForward semantics + NuGet cache); README test inventory updated.

## Test plan

- [x] `make lint` — green
- [x] `make test` — 6/6 unit pass
- [x] `make integration-test` — 8/8 pass (4 StateStore + 3 Endpoints + 1 SubscriptionContract)
- [x] `make e2e` — 10/10 assertions pass (including new POST status/Location and Jaeger trace-content checks)
- [x] `make ci` — composite green
- [x] `make ci-run` (full act loop: static-check + build + test + integration-test + e2e + ci-pass) — exit 0
- [x] Renovate validation — `LOG_LEVEL=debug npx renovate --platform=local` extracts both `MERMAID_CLI_VERSION` and `ACT_UBUNTU_VERSION` cleanly
- [x] Lint guard mutation-tested — `chmod -x scripts/pick-port.sh && make lint` fails with the expected error; restoring +x re-greens