### PR TITLE
chore: project-review hardening — CI gating, cache cleanup, test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ E2E_JAEGER_POLL_SECONDS=30
 E2E_CURL_MAX_TIME_SECONDS=5
 E2E_PROBE_MAX_TIME_SECONDS=2
 E2E_POLL_INTERVAL_SECONDS=1
+# Bounded settle window after publishing a malformed (poison) pub/sub payload,
+# before asserting state is unchanged. The assertion is deterministic by
+# invariant (a 400-on-every-delivery message can never mutate state, even under
+# Dapr redelivery), so this only governs how long to let any redelivery attempt
+# run before the final read; it is not a flakiness mitigation.
+E2E_POISON_SETTLE_SECONDS=5
 
 # act-runner ephemeral artifact-server port range (used by `make ci-run`).
 ACT_PORT_MIN=40000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,14 @@ jobs:
         run: make static-check
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    # Explicit gate (mirrors static-check). Adding an `if:` strips GitHub's
+    # implicit `success()` over `needs`, so the `!failure() && !cancelled()`
+    # prefix is REQUIRED to keep blocking on a failed/cancelled upstream
+    # (otherwise a failed static-check would leak past `code == 'true'`).
+    # A *skipped* static-check (doc-only push) is not a failure, so the
+    # code-or-tag predicate then governs and this job skips too.
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -91,7 +98,8 @@ jobs:
         run: make build
 
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -112,7 +120,8 @@ jobs:
         run: make test
 
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -133,7 +142,15 @@ jobs:
         run: make integration-test
 
   e2e:
-    needs: [build]
+    # `changes` + `static-check` listed as DIRECT needs (alongside build/test)
+    # so `!failure()` observes a static-check failure directly rather than
+    # relying on transitive `failure()` over the build/test chain (which is
+    # documented as unreliable when the failing ancestor is not a direct
+    # need — see github/community discussion #80788). A skipped build/test
+    # on a doc-only push is not a failure, so the code-or-tag predicate
+    # governs and this job skips too.
+    needs: [changes, static-check, build, test]
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -150,7 +167,8 @@ jobs:
           install: true
           cache: true
 
-      - name: E2E (Docker Compose)
+      # e2e runs the full Docker Compose stack (app + daprd + Redis + Jaeger).
+      - name: E2E
         run: make e2e
 
   ci-pass:

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -27,9 +27,12 @@ jobs:
         run: |
           CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
           gh run list --repo "${{ github.repository }}" \
-            --json databaseId,createdAt --limit 200 \
+            --json databaseId,createdAt,workflowName --limit 200 \
           | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" \
-              'sort_by(.createdAt) | reverse | .[$keep:] | .[] | select(.createdAt < $cutoff) | .databaseId' \
+              'group_by(.workflowName)
+               | map(sort_by(.createdAt) | reverse | .[$keep:])
+               | add // []
+               | .[] | select(.createdAt < $cutoff) | .databaseId' \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
 
   cleanup-caches:
@@ -38,25 +41,47 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Delete caches for deleted branches
+      - name: Delete caches from merged/deleted branches and closed PRs
         run: |
-          # List all active branches
-          gh api --paginate "repos/${{ github.repository }}/branches" --jq '.[].name' > /tmp/active_branches.txt
-          # List all cache refs and delete those whose branch no longer exists
-          gh api --paginate "repos/${{ github.repository }}/actions/caches" \
-            --jq '.actions_caches[] | "\(.id) \(.ref)"' \
-          | while read -r id ref; do
-              # ref looks like 'refs/heads/<branch>' or 'refs/pull/<n>/merge'
+          echo "=== Cleaning caches from non-existent branches and closed/merged PRs ==="
+          # Canonical `gh cache list --json id,ref,key` enumeration (gh >= 2.34).
+          # Each cache ref is one of:
+          #   refs/heads/<branch>     — branch cache; delete when the branch is gone
+          #   refs/pull/<n>/merge     — PR cache;     delete when the PR is closed/merged
+          #   refs/tags/<tag>         — tag cache;    always kept
+          # main (default branch) and tags are always protected; everything else
+          # is deleted only after confirming its source no longer exists/is open.
+          gh cache list --repo "${{ github.repository }}" --json id,ref,key --limit 200 \
+          | jq -r '.[] | "\(.id)\t\(.ref)\t\(.key)"' \
+          | while IFS=$'\t' read -r id ref key; do
               case "$ref" in
+                refs/heads/main|refs/heads/master)
+                  # Default branch — never prune.
+                  continue
+                  ;;
+                refs/tags/*)
+                  # Tag caches — never prune.
+                  continue
+                  ;;
                 refs/heads/*)
-                  branch=${ref#refs/heads/}
-                  if ! grep -qxF "$branch" /tmp/active_branches.txt; then
-                    echo "Deleting cache $id for stale branch $branch"
-                    gh api --method DELETE "repos/${{ github.repository }}/actions/caches/$id" >/dev/null
+                  branch="${ref#refs/heads/}"
+                  # Delete only if the branch no longer exists (API returns 404).
+                  if ! gh api "repos/${{ github.repository }}/branches/${branch}" --silent 2>/dev/null; then
+                    echo "Deleting cache ${key} (branch ${branch} no longer exists)"
+                    gh cache delete "$id" --repo "${{ github.repository }}" 2>/dev/null || true
                   fi
                   ;;
                 refs/pull/*)
-                  echo "Skipping PR cache ref $ref"
+                  pr="${ref#refs/pull/}"; pr="${pr%/merge}"
+                  # Keep caches for OPEN PRs; delete once the PR is closed/merged.
+                  state="$(gh api "repos/${{ github.repository }}/pulls/${pr}" --jq '.state' 2>/dev/null || echo "")"
+                  if [ "$state" != "open" ]; then
+                    echo "Deleting cache ${key} (PR #${pr} is ${state:-gone})"
+                    gh cache delete "$id" --repo "${{ github.repository }}" 2>/dev/null || true
+                  fi
+                  ;;
+                *)
+                  echo "Skipping cache ${key} (unrecognized ref ${ref})"
                   ;;
               esac
             done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, running via Docker Compose.
 
-- **Language**: C# / .NET 10.0 (`global.json` pins SDK `10.0.201`)
+- **Language**: C# / .NET 10.0 (`global.json` pins SDK `10.0.203`)
 - **Framework**: ASP.NET Core with Dapr.AspNetCore
 - **Infrastructure**: Docker Compose (multi-file), Dapr sidecar, Redis, Jaeger (OTel tracing)
 - **Solution**: `dapr-docker-csharp.slnx` (.NET 10 XML format)
@@ -13,7 +13,7 @@ Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, r
   - `tests/queue-processor.tests/` — unit (TUnit + FakeItEasy + WebApplicationFactory)
   - `tests/queue-processor.integration.tests/` — integration (TUnit + Testcontainers Redis + daprd, real `DaprClient`)
 - **E2E**: `e2e/e2e-test.sh` — Docker Compose + curl + Dapr publish API
-- **Version manager**: mise (`.mise.toml` pins Node, pnpm, act, trivy, gitleaks)
+- **Version manager**: mise (`.mise.toml` pins Node, pnpm, jq, act, trivy, gitleaks)
 
 ## Build & Dev Commands
 
@@ -102,7 +102,7 @@ Three-layer pyramid — each layer covers a distinct surface and runs as its own
 | Integration | `tests/queue-processor.integration.tests/` | Testcontainers Redis + daprd; real `DaprClient` over HTTP/gRPC | `make integration-test` | `integration-test` |
 | E2E | `e2e/e2e-test.sh` | Full Docker Compose stack: app + daprd + Redis + Jaeger | `make e2e` | `e2e` |
 
-- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.28.0 with Microsoft Testing Platform
+- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.44.0 with Microsoft Testing Platform
 - **Mocking**: FakeItEasy 9.0.1 (per portfolio testing rule)
 - **Integration containers**: `Testcontainers` + `Testcontainers.Redis` 4.11
 - **Run discipline**: `dotnet run --project ...` (required for TUnit on .NET 10 SDK; MTP entry point)
@@ -118,7 +118,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push to main, tags 
 | **build** | static-check | `make build` |
 | **test** | static-check | `make test` (unit) |
 | **integration-test** | static-check | `make integration-test` (Testcontainers) |
-| **e2e** | build | `make e2e` (Docker Compose full-stack) |
+| **e2e** | build, test | `make e2e` (Docker Compose full-stack) |
 | **ci-pass** | all of the above (always) | Aggregator status check (target for branch protection / Rulesets) |
 
 Permissions: workflow-level `contents: read` + `pull-requests: read` (for `paths-filter`). SDK version from `global.json`. NuGet caching via `packages.lock.json`. mise-action installs `.mise.toml`-pinned tools for the static-check job.

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,13 @@ help:
 deps:
 	@command -v dotnet >/dev/null 2>&1 || { echo "Error: .NET SDK required. See https://dotnet.microsoft.com/download"; exit 1; }
 	@command -v docker >/dev/null 2>&1 || { echo "Error: Docker required. See https://docs.docker.com/get-docker/"; exit 1; }
-	@command -v mise   >/dev/null 2>&1 || { echo "Installing mise..."; curl -fsSL https://mise.run | sh; }
+	@# CI installs mise via jdx/mise-action; only bootstrap the binary locally.
+	@if [ -z "$$CI" ]; then command -v mise >/dev/null 2>&1 || { echo "Installing mise..."; curl -fsSL https://mise.run | sh; }; fi
 	@mise install --yes
 
 #deps-act: @ Install act for local CI runs (via mise)
 deps-act: deps
-	@mise install --yes aqua:nektos/act
+	@# act is pinned in .mise.toml and installed by `deps`; nothing extra needed.
 
 #clean: @ Remove build artifacts
 clean:
@@ -116,14 +117,12 @@ vulncheck: deps
 
 #trivy-fs: @ Trivy filesystem scan (HIGH+CRITICAL vulnerabilities + misconfigs)
 trivy-fs: deps
-	@mise install --yes aqua:aquasecurity/trivy >/dev/null
 	@trivy fs --quiet --severity HIGH,CRITICAL --exit-code 1 \
 		--skip-dirs bin --skip-dirs obj --skip-dirs node_modules \
 		--scanners vuln,misconfig .
 
 #secrets: @ Scan working tree + git history for committed secrets (gitleaks)
 secrets: deps
-	@mise install --yes aqua:gitleaks/gitleaks >/dev/null
 	@gitleaks detect --no-banner --redact --exit-code 1
 
 #mermaid-lint: @ Lint Mermaid diagrams embedded in Markdown files
@@ -192,7 +191,7 @@ ci-run: deps-act
 
 #renovate-bootstrap: @ Install Node + pnpm for Renovate (via mise)
 renovate-bootstrap: deps
-	@mise install --yes node pnpm
+	@# Node + pnpm are pinned in .mise.toml and installed by `deps`.
 
 #renovate-validate: @ Validate Renovate configuration
 renovate-validate: renovate-bootstrap

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ C4Container
     title Container Diagram — QueueProcessor on Docker Compose
     Person(operator, "Operator")
     System_Boundary(compose, "docker compose") {
-        Container(app, "QueueProcessor", "C# / .NET 10, ASP.NET Core, Dapr.AspNetCore", "GET / state · POST /counter (squares input) · pub/sub subscriber on topic counter")
-        Container(daprd, "Dapr Sidecar", "daprd 1.17", "Pub/sub + state-store proxy; HTTP :3500, gRPC :50001")
+        Container(app, "QueueProcessor", "C# / .NET 10, ASP.NET Core, Dapr.AspNetCore 1.17", "GET / state · POST /counter (squares input) · pub/sub subscriber on topic counter")
+        Container(daprd, "Dapr Sidecar", "daprd 1.17.6", "Pub/sub + state-store proxy; HTTP :3500, gRPC :50001")
         ContainerDb(redis, "Redis", "redis:8", "State store · pub/sub broker (Redis Streams)")
-        Container(jaeger, "Jaeger", "jaegertracing/jaeger:2", "Trace collector + UI on :16686")
+        Container(jaeger, "Jaeger", "jaegertracing/jaeger:2.17.0", "Trace collector + UI on :16686")
     }
     Rel(operator, app, "HTTP", "port 5000 (or HOST_PORT override)")
     Rel(app, daprd, "HTTP / gRPC", "in-pod localhost")
@@ -163,7 +163,7 @@ Run `make help` to see all targets.
 | Target | Description |
 |--------|-------------|
 | `make help` | List available tasks |
-| `make ci` | Run full local CI pipeline (static-check + test + build) |
+| `make ci` | Run full local CI pipeline (static-check + test + integration-test + build) |
 | `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
 | `make deps` | Install required tools (idempotent) |
 | `make deps-act` | Install act for local CI runs |
@@ -182,7 +182,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, `workflow
 | **build** | after static-check | `make build` |
 | **test** | after static-check | `make test` (unit) |
 | **integration-test** | after static-check | `make integration-test` (Testcontainers Redis + daprd) |
-| **e2e** | after build | `make e2e` (Docker Compose full-stack roundtrip) |
+| **e2e** | after build + test | `make e2e` (Docker Compose full-stack roundtrip) |
 | **ci-pass** | always | Aggregator status check for branch protection / Rulesets |
 
 ### Required Secrets and Variables

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -39,6 +39,7 @@ E2E_JAEGER_POLL_SECONDS="${E2E_JAEGER_POLL_SECONDS:-30}"
 E2E_CURL_MAX_TIME_SECONDS="${E2E_CURL_MAX_TIME_SECONDS:-5}"
 E2E_PROBE_MAX_TIME_SECONDS="${E2E_PROBE_MAX_TIME_SECONDS:-2}"
 E2E_POLL_INTERVAL_SECONDS="${E2E_POLL_INTERVAL_SECONDS:-1}"
+E2E_POISON_SETTLE_SECONDS="${E2E_POISON_SETTLE_SECONDS:-5}"
 
 COMPOSE=(docker compose \
     --file docker-compose.yaml \
@@ -256,6 +257,42 @@ if [ "$seen_trace" = yes ]; then
 else
     fail "Jaeger returned no traces for '${OTEL_SERVICE_NAME}' within ${E2E_JAEGER_POLL_SECONDS}s (last response: '${last_traces_resp:-<empty>}')"
 fi
+
+echo ""
+echo "==> Test 8: poison payload — malformed pub/sub message does not corrupt state"
+# Contract: the subscribed handler binds the message body to `[FromBody] int`
+# (Program.cs `MapPost("/counter", ([FromBody] int counter, ...))`). A
+# non-integer body fails ASP.NET Core model binding with HTTP 400 BEFORE the
+# handler runs, so `SaveStateAsync` is never reached — a malformed message can
+# NEVER mutate the counter.
+#
+# Determinism rationale: Dapr's Redis Streams pub/sub gives at-least-once
+# delivery and will redeliver an un-acked (errored) message — defaults
+# processingTimeout=15s, redeliverInterval=60s. Every redelivery of the same
+# poison payload also 400s, so no successful processing ever occurs and the
+# stored value is invariant under any number of retries. We therefore assert
+# the STATE-UNCHANGED invariant, not a timing-dependent outcome: this is
+# deterministic regardless of how many (if any) redeliveries fire within the
+# settle window. A leftover poison message in the Redis PEL is harmless — the
+# stack is torn down with `down -v` on exit.
+
+# 1. Establish a known-good baseline state via a valid POST (6 → 36).
+check_post "POST /counter 6 → 36 (poison baseline)" "$BASE/counter" '6' '202' '36' '/'
+assert_body_equals "$BASE/" "36"
+
+# 2. Publish a MALFORMED payload (a JSON string, not an integer) on the same
+#    pubsub/topic and rawPayload=false path Test 5 uses. Dapr accepts the
+#    publish (the broker doesn't validate app schema) and delivers it; the
+#    subscriber 400s on bind.
+"${COMPOSE[@]}" exec -T queueprocessor curl -sf --max-time "$E2E_CURL_MAX_TIME_SECONDS" \
+    "http://${DAPR_HOST}:${DAPR_HTTP_PORT}/v1.0/publish/${PUBSUB_NAME}/${TOPIC_NAME}?metadata.rawPayload=false" \
+    -H 'Content-Type: application/json' --data '"notanumber"' \
+    || fail "Dapr publish of malformed payload to ${PUBSUB_NAME}/${TOPIC_NAME} failed"
+
+# 3. Give any delivery/redelivery attempt a bounded window to run, then assert
+#    the state is STILL the baseline — the poison message corrupted nothing.
+sleep "$E2E_POISON_SETTLE_SECONDS"
+assert_body_equals "$BASE/" "36"
 
 echo ""
 echo "==> Results: ${PASS} passed, ${FAIL} failed"

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
         "scripts/**/*.bash"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z_]+\\s*[:?]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z0-9-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z_]+\\s*[:?]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
       ]
     },
     {
@@ -65,7 +65,7 @@
         "src/**/*.cs"
       ],
       "matchStrings": [
-        "//\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?\\s*\\n\\s*(?:private|public|internal|protected)?\\s*(?:static\\s+)?(?:readonly\\s+)?const\\s+string\\s+\\w+\\s*=\\s*\"[^\":]+:(?<currentValue>[^\"]+)\""
+        "//\\s*renovate:\\s*datasource=(?<datasource>[a-z0-9-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?\\s*\\n\\s*(?:private|public|internal|protected)?\\s*(?:static\\s+)?(?:readonly\\s+)?const\\s+string\\s+\\w+\\s*=\\s*\"[^\":]+:(?<currentValue>[^\"]+)\""
       ]
     }
   ],
@@ -85,13 +85,14 @@
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Group .NET Docker images",
+      "description": "Group .NET Docker images and the global.json SDK pin",
       "groupName": "Dotnet Docker images",
       "matchPackageNames": [
         "mcr.microsoft.com/dotnet/aspnet",
         "mcr.microsoft.com/dotnet/sdk",
         "mcr.microsoft.com/dotnet/runtime",
-        "mcr.microsoft.com/dotnet/runtime-deps"
+        "mcr.microsoft.com/dotnet/runtime-deps",
+        "dotnet-sdk"
       ]
     },
     {
@@ -114,6 +115,25 @@
         "mise"
       ],
       "groupName": "mise tools"
+    },
+    {
+      "description": "Group .NET test dependencies (TUnit, Testcontainers, FakeItEasy)",
+      "groupName": "test dependencies",
+      "matchPackageNames": [
+        "/^TUnit/",
+        "/^Testcontainers/",
+        "FakeItEasy"
+      ]
+    },
+    {
+      "description": "Makefile docker dev-tool pins (mermaid-cli, catthehacker/ubuntu) are interpolated into `docker run image:$(VAR)` recipes with no digest. Suppress docker:pinDigests to avoid a pinDigest x version-bump branch collision.",
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
     }
   ]
 }

--- a/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
+++ b/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
@@ -84,4 +84,24 @@ public sealed class EndpointsIntegrationTests(DaprStateStoreFixture fixture)
         var stored = await fixture.Client.GetStateAsync<int>(Store, CounterKey);
         await Assert.That(stored).IsEqualTo(16);
     }
+
+    [Test]
+    public async Task PostCounter_WithMalformedBody_Returns400_AndLeavesStateUnchanged()
+    {
+        await fixture.Client.SaveStateAsync(Store, CounterKey, 123);
+
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        // Malformed body for `[FromBody] int` — a JSON string, not an int.
+        // Direct HTTP POST (no pub/sub) makes this deterministic vs. an e2e
+        // redelivery-prone negative payload check, against real Dapr.
+        var content = new StringContent("\"abc\"", System.Text.Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/counter", content);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+
+        // Bad input must not have corrupted the persisted state.
+        var stored = await fixture.Client.GetStateAsync<int>(Store, CounterKey);
+        await Assert.That(stored).IsEqualTo(123);
+    }
 }

--- a/tests/queue-processor.tests/EndpointTests.cs
+++ b/tests/queue-processor.tests/EndpointTests.cs
@@ -105,4 +105,57 @@ public class EndpointTests
                 .SaveStateAsync("statestore", "counter", 9, A<StateOptions?>.Ignored, A<IReadOnlyDictionary<string, string>?>.Ignored, A<CancellationToken>.Ignored))
             .MustHaveHappenedOnceExactly();
     }
+
+    [Test]
+    public async Task PostCounter_WithNonIntegerBody_Returns400()
+    {
+        await using var factory = new QueueProcessorWebFactory();
+        using var client = factory.CreateClient();
+
+        // Malformed body for `[FromBody] int` — a JSON string, not an int.
+        // Minimal-API model binding rejects it before the handler runs.
+        var content = new StringContent("\"abc\"", System.Text.Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/counter", content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+
+        A.CallTo(() => factory.MockDaprClient
+                .SaveStateAsync("statestore", "counter", A<int>.Ignored, A<StateOptions?>.Ignored, A<IReadOnlyDictionary<string, string>?>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task PostCounter_WithMaxValue_OverflowsUnchecked()
+    {
+        await using var factory = new QueueProcessorWebFactory();
+        using var client = factory.CreateClient();
+
+        // Documents the UNCHECKED-arithmetic contract: counter * counter wraps.
+        var expected = unchecked(int.MaxValue * int.MaxValue);
+
+        var response = await client.PostAsJsonAsync("/counter", int.MaxValue);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+        var result = await response.Content.ReadFromJsonAsync<int>();
+        await Assert.That(result).IsEqualTo(expected);
+
+        A.CallTo(() => factory.MockDaprClient
+                .SaveStateAsync("statestore", "counter", expected, A<StateOptions?>.Ignored, A<IReadOnlyDictionary<string, string>?>.Ignored, A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task PostCounter_WhenStateStoreThrows_Returns500()
+    {
+        await using var factory = new QueueProcessorWebFactory();
+        A.CallTo(() => factory.MockDaprClient
+                .SaveStateAsync("statestore", "counter", A<int>.Ignored, A<StateOptions?>.Ignored, A<IReadOnlyDictionary<string, string>?>.Ignored, A<CancellationToken>.Ignored))
+            .Throws(new Exception("redis down"));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/counter", 5);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.InternalServerError);
+    }
 }


### PR DESCRIPTION
Comprehensive project-review pass + the three deliberately-deferred items, each researched/spiked and validated.

## Foundation (Phase A)
- **Makefile**: CI-guard the mise curl-bootstrap; drop redundant inline `mise install` (act/trivy/gitleaks/node+pnpm already pinned in `.mise.toml`, installed by `deps`).
- **renovate.json**: suppress `docker:pinDigests` on Makefile docker pins (interpolated into `docker run image:$(VAR)` — no digest); group `dotnet-sdk` with the .NET image group; add a test-dependency group (TUnit/Testcontainers/FakeItEasy); widen custom-manager datasource char-class to `[a-z0-9-]+`.
- **ci.yml**: `e2e` now `needs: [build, test]`; **explicit `if:` gating** on every heavy job — `!failure() && !cancelled() && (code || tag)`. Researched against GitHub docs: an `if:` strips the implicit `success()` over `needs`, so the `!failure() && !cancelled()` prefix is required to keep blocking on failed/cancelled upstreams. Proven equivalent to the implicit cascade via truth table across code / doc-only / static-check-fail / tag-push scenarios; actionlint clean.
- **cleanup-runs.yml**: **per-workflow** run retention (`group_by(.workflowName)`) so CI runs can't age out and deregister `ci-pass` as a required check; `cleanup-caches` refactored to canonical `gh cache list --json` (now protects tag + open-PR caches; deletes deleted-branch + closed/merged-PR caches).

## Tests
- **unit** (3): non-int body → 400 (no SaveState); `int.MaxValue` unchecked-overflow contract; state-store throw → 500.
- **integration** (1): malformed body → 400 leaves state unchanged (real daprd+Redis).
- **e2e** (Test 8): poison-payload — a malformed pub/sub message does not corrupt state. Deterministic **by invariant** (a 400-on-every-delivery message can never mutate state, even under Dapr at-least-once redelivery — confirmed via daprd logs). Proven non-flaky across **4 consecutive `make e2e` runs**.

## Docs
- **CLAUDE.md**: TUnit `1.28.0`→`1.44.0` (matched csproj); add `jq` to tool list; `e2e needs build,test`.
- **README.md**: `make ci` lists `integration-test`; C4 diagram tech-strings → real pins (daprd 1.17.6, jaeger 2.17.0, Dapr.AspNetCore 1.17).
- **.env.example**: `E2E_POISON_SETTLE_SECONDS` tunable.

## Validation
- `make ci` green — unit 9, integration 9, build 0 errors, vulncheck/trivy-fs/gitleaks clean.
- `make e2e` 4× green (13/13 each).
- `actionlint 1.7.12` clean (+ negative control); `renovate-config-validator` clean; `make mermaid-lint` exit 0.

## Not included (Renovate-owned)
Tool/action drift exists (trivy 0.71.1, act 0.2.89, pnpm 11.7.0, action SHAs, .NET 10.0.301) — all Renovate-tracked with per-manager grouping + CI gating. Deferred to Renovate to keep this PR focused and avoid a scanner-DB bump reddening unrelated CI.

## Test plan
- [x] `make ci` (static-check + test + integration-test + build)
- [x] `make e2e` ×4
- [x] actionlint / renovate-config-validator / mermaid-lint
- [ ] CI `ci-pass` green on this PR