### PR TITLE
chore: .NET SDK 10.0.301 + base-image digests + HEALTHCHECK fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, running via Docker Compose.
 
-- **Language**: C# / .NET 10.0 (`global.json` pins SDK `10.0.203`)
+- **Language**: C# / .NET 10.0 (`global.json` pins SDK `10.0.301`)
 - **Framework**: ASP.NET Core with Dapr.AspNetCore
 - **Infrastructure**: Docker Compose (multi-file), Dapr sidecar, Redis, Jaeger (OTel tracing)
 - **Solution**: `dapr-docker-csharp.slnx` (.NET 10 XML format)
@@ -90,7 +90,7 @@ Pinned in `.mise.toml` and Renovate-tracked:
 - **trivy**: 0.71.1 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
 - **mermaid-cli**: 11.14.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
-- **.NET SDK**: 10.0.203 (from `global.json`)
+- **.NET SDK**: 10.0.301 (from `global.json`)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 | Component | Technology |
 |-----------|------------|
-| Language | C# / .NET 10.0 LTS (SDK 10.0.203 via `global.json`, `rollForward: latestFeature`) |
+| Language | C# / .NET 10.0 LTS (SDK 10.0.301 via `global.json`, `rollForward: latestFeature`) |
 | Framework | ASP.NET Core (`Microsoft.NET.Sdk.Web`), `Dapr.AspNetCore` 1.18 |
 | Messaging | Dapr pub/sub on Redis Streams |
 | State store | Dapr state on Redis |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
     network_mode: service:queueprocessor
 
   redis:
-    image: redis:8@sha256:0c341492924cad6f5483f9133e43bd6c51ecdecbcadfac5b51657393b6a7936c
+    image: redis:8@sha256:0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973
     ports:
       - "${REDIS_HOST_PORT:-6379}:6379"
     networks:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.203",
+    "version": "10.0.301",
     "rollForward": "latestFeature"
   }
 }

--- a/src/queue-processor/Dockerfile
+++ b/src/queue-processor/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ----- Build stage -----
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:f061e5a7532b36fa1d1b684857fe1f504ba92115b9934f154643266613c44c62 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
 WORKDIR /src
 
 # Copy csproj + lockfile first for cache-friendly restore.
@@ -16,7 +16,7 @@ RUN dotnet publish src/queue-processor/queue-processor.csproj \
     -o /app/publish
 
 # ----- Runtime stage -----
-FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:55e37c7795bfaf6b9cc5d77c155811d9569f529d86e20647704bc1d7dd9741d4 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS runtime
 
 # curl is required by Docker HEALTHCHECK. Install + clean apt lists in one layer.
 # Microsoft's aspnet:10.0 image already ships a non-root `app` user (UID 1654);
@@ -34,10 +34,6 @@ USER app:app
 # Override at build time with `--build-arg KEY=value` (see Makefile image-build).
 ARG APP_INTERNAL_PORT=5000
 ARG HEALTHCHECK_HOST=localhost
-ARG HEALTHCHECK_INTERVAL=30s
-ARG HEALTHCHECK_TIMEOUT=3s
-ARG HEALTHCHECK_START_PERIOD=20s
-ARG HEALTHCHECK_RETRIES=3
 ENV APP_INTERNAL_PORT=${APP_INTERNAL_PORT} \
     HEALTHCHECK_HOST=${HEALTHCHECK_HOST} \
     ASPNETCORE_URLS=http://*:${APP_INTERNAL_PORT} \
@@ -47,10 +43,12 @@ ENV APP_INTERNAL_PORT=${APP_INTERNAL_PORT} \
 EXPOSE ${APP_INTERNAL_PORT}
 
 # Liveness probe: the /healthz endpoint registered by AddHealthChecks in Program.cs.
-# HEALTHCHECK flags use build-time ARG substitution (BuildKit). The CMD args
-# use `${ENV}` runtime expansion so `docker run -e …` overrides reach the probe.
-HEALTHCHECK --interval=${HEALTHCHECK_INTERVAL} --timeout=${HEALTHCHECK_TIMEOUT} \
-    --start-period=${HEALTHCHECK_START_PERIOD} --retries=${HEALTHCHECK_RETRIES} \
+# HEALTHCHECK flag timings MUST be literal durations — they are parsed at
+# Dockerfile-parse time and are NOT ARG/ENV-expanded (`--interval=${VAR}` fails
+# the build with `invalid duration`). The CMD body, by contrast, runs under
+# /bin/sh at container start and DOES honor ${ENV}, so the probe host/port stay
+# runtime-tunable via `docker run -e HEALTHCHECK_HOST=… -e APP_INTERNAL_PORT=…`.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
     CMD curl -sf "http://${HEALTHCHECK_HOST}:${APP_INTERNAL_PORT}/healthz" || exit 1
 
 ENTRYPOINT ["dotnet", "queue-processor.dll"]


### PR DESCRIPTION
The deferred items from the upgrade pass, applied + validated, plus a latent Dockerfile bug found while validating.

## Changes
- **.NET SDK 10.0.203 → 10.0.301** (`global.json`), aligned with the `dotnet/sdk:10.0` + `dotnet/aspnet:10.0` base-image digests bumped to the 10.0.301-containing images (the alignment the deferral was about — `dotnet-sdk` is grouped with these images in `renovate.json` for future bumps).
- **redis:8 digest** refreshed to latest 8.x. daprd:1.17.6 + jaeger:2.17.0 digests are **unchanged** (immutable version tags — digest refresh is a no-op).
- **HEALTHCHECK build-breaking bug fixed** — flags used `--interval=${HEALTHCHECK_INTERVAL}` etc., but HEALTHCHECK flag timings are parsed at Dockerfile-parse time and are **not** ARG/ENV-expanded, so `make image-build` failed with `invalid duration "${HEALTHCHECK_INTERVAL}"` (the image had never built). Flags are now literal (30s/3s/20s/3); the four dead ARGs removed; the CMD body keeps `${HEALTHCHECK_HOST}`/`${APP_INTERNAL_PORT}` (runtime-expanded, still tunable via `docker run -e`).
- Docs (README Tech Stack, CLAUDE.md) synced to SDK 10.0.301.

## Validation
- `make ci` green (SDK 10.0.301 resolves locally; unit 9, integration 9, build 0 err, scans clean).
- `make image-build` now **succeeds** (was broken by the HEALTHCHECK bug).
- Container runtime smoke: HEALTHCHECK → **healthy** (probe exit 0); app logs `Now listening on http://[::]:5000`.
- `make e2e` 13/13 (redis digest + full stack).
- Hardcoded-value audit clean.

## Test plan
- [x] make ci · make image-build · container HEALTHCHECK healthy · make e2e
- [ ] CI ci-pass green