### PR TITLE
chore(renovate): 3-day minimumReleaseAge on mise tools group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,11 +110,12 @@
       ]
     },
     {
-      "description": "Group mise-managed tools",
+      "description": "Group mise tool bumps + hold each new version 3 days so the upstream GitHub Release artifacts that mise's aqua:/github-tags backend installs are published before the PR opens — prevents the tag-before-publish 404 on `mise install` (trivy/act/gitleaks are aqua: tools that push the git tag before the release).",
       "matchManagers": [
         "mise"
       ],
-      "groupName": "mise tools"
+      "groupName": "mise tools",
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Group .NET test dependencies (TUnit, Testcontainers, FakeItEasy)",


### PR DESCRIPTION
`/renovate` review — the config was already brought up to spec earlier this session (all 27 checklist items pass). One real MEDIUM finding remained and is fixed here.

## Finding
The `mise tools` group had no `minimumReleaseAge`. mise's `aqua:`/`github-tags` backend installs from GitHub **Release** artifacts but tracks git **tags**, so Renovate can open a bump the instant a tag is pushed — before the release artifact publishes — and `mise install` then 404s, reddening `static-check`/`build`. This repo's trivy/act/gitleaks are all `aqua:` tools in that tag-before-publish class (we observed trivy 0.71.1 / act 0.2.89 available during the upgrade pass).

## Fix
Folded `minimumReleaseAge: "3 days"` into the existing `mise tools` group (manager-wide buffer — covers all current + future mise tools, not an enumerable allowlist), per the `/renovate` skill's canonical mitigation.

## Validation
`make renovate-validate` clean (no `validationError`).

## Note (residual, not changed here)
`platformAutomerge: true` has a documented registration-race where a bump can native-auto-merge in the ~1s before its CI check registers. `ci-pass` is now a required check (the primary gate); the categorical race-fix is `platformAutomerge: false` (slower — waits for Renovate's next run). Left as-is; flagging as a speed-vs-safety posture choice rather than flipping it unilaterally.

## Test plan
- [x] make renovate-validate
- [ ] ci-pass green (renovate.json is not in the paths-filter `code` set, so heavy jobs skip by design)