### PR TITLE
chore: align Dapr runtime to SDK (daprd 1.18.1), jaeger 2.19.0, mermaid-cli 11.15.0, automerge race-fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Pinned in `.mise.toml` and Renovate-tracked:
 - **act**: 0.2.89 (`aqua:nektos/act`)
 - **trivy**: 0.71.1 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
-- **mermaid-cli**: 11.14.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
+- **mermaid-cli**: 11.15.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
 - **.NET SDK**: 10.0.301 (from `global.json`)
 
 ## Testing
@@ -144,6 +144,10 @@ The Dapr `Configuration` CR (`compose/configuration/configuration.yaml`) wires d
 | Command | Purpose |
 |---------|---------|
 | `make image-build` | Build the production image (`queue-processor:<git-describe>` + `:latest`) via multi-stage Dockerfile with non-root `app:app` user and HEALTHCHECK |
+
+## Upgrade Backlog
+
+- [ ] **Reactivate Renovate (Mend Cloud GitHub App).** Renovate stopped running on this repo ~2026-03-30 (last bot PR #27; Dependency Dashboard #4 last updated 2026-03-30, still showing pre-`#32` state). Until the app is reinstalled/reauthorized at <https://github.com/apps/renovate> (or the repo's status is fixed at developer.mend.io), dependency automation and `automerge` are dead — every dependency must be bumped manually, and the `renovate.json` config (incl. the mise `minimumReleaseAge` buffer and `platformAutomerge: false` race-fix) is inert. External GitHub-App OAuth action; cannot be done from the repo. Once reactivated, the dashboard reconciles on the first run and the registration-race fix (`platformAutomerge: false`) takes effect.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CURRENTTAG     := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "de
 
 # === Tool versions (managed by mise — see .mise.toml) ===
 # renovate: datasource=docker depName=minlag/mermaid-cli
-MERMAID_CLI_VERSION := 11.14.0
+MERMAID_CLI_VERSION := 11.15.0
 
 # act runner image. CI uses GitHub-hosted `ubuntu-latest`; act needs an
 # equivalent locally. Pin the DATED catthehacker tag (immutable, content-

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ C4Container
     Person(operator, "Operator")
     System_Boundary(compose, "docker compose") {
         Container(app, "QueueProcessor", "C# / .NET 10, ASP.NET Core, Dapr.AspNetCore 1.18", "GET / state · POST /counter (squares input) · pub/sub subscriber on topic counter")
-        Container(daprd, "Dapr Sidecar", "daprd 1.17.6", "Pub/sub + state-store proxy; HTTP :3500, gRPC :50001")
+        Container(daprd, "Dapr Sidecar", "daprd 1.18.1", "Pub/sub + state-store proxy; HTTP :3500, gRPC :50001")
         ContainerDb(redis, "Redis", "redis:8", "State store · pub/sub broker (Redis Streams)")
-        Container(jaeger, "Jaeger", "jaegertracing/jaeger:2.17.0", "Trace collector + UI on :16686")
+        Container(jaeger, "Jaeger", "jaegertracing/jaeger:2.19.0", "Trace collector + UI on :16686")
     }
     Rel(operator, app, "HTTP", "port 5000 (or HOST_PORT override)")
     Rel(app, daprd, "HTTP / gRPC", "in-pod localhost")

--- a/compose/dapr-docker-compose.yaml
+++ b/compose/dapr-docker-compose.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json
 services:
   jaeger:
-    image: jaegertracing/jaeger:2.17.0@sha256:6266573208d665ce5c17483bce0a75d0806480d92c84766d288d0aee885ce708
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     ports:
       - "${JAEGER_QUERY_HOST_PORT:-16686}:16686"
       - "${JAEGER_OTLP_GRPC_HOST_PORT:-4317}:4317"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     networks:
       - dapr-demo-network
   queueprocessor-dapr:
-    image: daprio/daprd:1.17.6@sha256:f5ba4f35b995d0e066344ff24cac6eae38e6fc89797f5140aa153f6c7b6b6417
+    image: daprio/daprd:1.18.1@sha256:4434e34fd782db17094123be93a78c0b18556b5b1fca1f06448e54df24e51cdf
     command:
       - "./daprd"
       - "--app-id"

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",

--- a/tests/queue-processor.integration.tests/DaprStateStoreFixture.cs
+++ b/tests/queue-processor.integration.tests/DaprStateStoreFixture.cs
@@ -11,7 +11,7 @@ namespace QueueProcessor.IntegrationTests;
 public sealed class DaprStateStoreFixture : IAsyncInitializer, IAsyncDisposable
 {
     // renovate: datasource=docker depName=daprio/daprd
-    private const string DaprdImage = "daprio/daprd:1.17.6";
+    private const string DaprdImage = "daprio/daprd:1.18.1";
     // renovate: datasource=docker depName=redis
     private const string RedisImage = "redis:8-alpine";
 


### PR DESCRIPTION
Applies the actionable findings from `/upgrade-analysis`. **Renovate is inactive on this repo since ~2026-03-30** (Dependency Dashboard #4 last updated then; last bot PR #27), so these are manual bumps — and the reactivation is tracked as a new CLAUDE.md `## Upgrade Backlog` item (external GitHub-App action).

## Changes
- **daprd 1.17.6 → 1.18.1** (compose image+digest + integration fixture) — aligns the runtime with the `Dapr.AspNetCore`/`Dapr.Client` **1.18.4** SDK bumped earlier this session. SDK 1.18 supports runtime 1.18 **and** 1.17 (N-1), so the prior state was supported; this makes it the matched pairing. Dapr 1.18's only breaking change touching this stack — Redis-common TLS cert verification (#4261) — **does not apply** (components use plain `redis:6379`, no `enableTLS`). Validated by `make integration-test` + `make e2e` against 1.18.1.
- **jaeger 2.17.0 → 2.19.0** (compose image+digest). 2.18/2.19 breaking changes = metricstore/SPM + jaeger-ui + apiv3 param renames (deprecated aliases kept); the e2e uses the stable `/api/services` + `/api/traces` query API — **unaffected**, confirmed by e2e Test 7 (trace ingestion).
- **mermaid-cli 11.14.0 → 11.15.0** (Makefile constant; `make mermaid-lint` green).
- **`platformAutomerge: true → false`** — closes the registration race where a Renovate bump can native-auto-merge in the ~1s before its CI check registers (`ci-pass` is a required check). Renovate instead merges on its own later run after re-confirming green. Inert until Renovate is reactivated.
- Docs: README C4 diagram tech-strings (daprd 1.18.1, jaeger 2.19.0), CLAUDE.md mermaid-cli 11.15.0 + the Renovate-reactivation backlog item.

## Facts / no-guesses
- Both image **index digests independently resolved** via `docker buildx imagetools inspect` (daprd `4434e34…`, jaeger `ede4864…`) — not agent-supplied.
- Breaking-change scan of Dapr 1.18 + Jaeger 2.18/2.19 release notes against this project's actual surface (plain Redis, otel tracing config, stable Jaeger query API).

## Validation
- `make ci` green — unit 9, integration 9 (daprd 1.18.1), build 0 err, vulncheck/trivy/gitleaks clean.
- `make e2e` **13/13** (daprd 1.18.1 + jaeger 2.19.0 full stack).
- `make mermaid-lint` green; `renovate-validate` clean.

## Test plan
- [x] make ci · make e2e · make mermaid-lint · renovate-validate
- [ ] CI ci-pass green