### PR TITLE
chore: project-review follow-ups (cleanup-runs PR retention, renovate infra group, image-build CI job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,35 @@ jobs:
       - name: Build
         run: make build
 
+  image-build:
+    # Build-only validation of the production Dockerfile (no push — there is no
+    # publish workflow). Keeps the multi-stage build from rotting unvalidated:
+    # a HEALTHCHECK parse error / COPY-path drift / bad base digest would
+    # otherwise ship undetected since `make ci` and the other jobs never run
+    # `docker build`. setup-dotnet is required only so `make image-build`'s
+    # `deps` precondition (`command -v dotnet`) passes; the restore/publish
+    # happen inside the image build itself.
+    needs: [changes, static-check]
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
+
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: Image build
+        run: make image-build
+
   test:
     needs: [changes, static-check]
     if: ${{ !failure() && !cancelled() && (needs.changes.outputs.code == 'true' || startsWith(github.ref, 'refs/tags/v')) }}
@@ -173,7 +202,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, integration-test, e2e]
+    needs: [changes, static-check, build, image-build, test, integration-test, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   actions: write
+  pull-requests: read
 
 jobs:
   cleanup-runs:
@@ -26,13 +27,21 @@ jobs:
       - name: Delete old workflow runs
         run: |
           CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Head SHAs of all OPEN PRs — their runs are retained regardless of age
+          # so a slow/idle PR never loses the run carrying its required `ci-pass`
+          # check (which would leave the PR BLOCKED with zero reported checks).
+          OPEN_SHAS=$(gh pr list --repo "${{ github.repository }}" --state open \
+            --json headRefOid --jq '[.[].headRefOid]')
           gh run list --repo "${{ github.repository }}" \
-            --json databaseId,createdAt,workflowName --limit 200 \
-          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" \
+            --json databaseId,createdAt,workflowName,headSha --limit 200 \
+          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" --argjson open "$OPEN_SHAS" \
               'group_by(.workflowName)
                | map(sort_by(.createdAt) | reverse | .[$keep:])
                | add // []
-               | .[] | select(.createdAt < $cutoff) | .databaseId' \
+               | .[]
+               | select(.createdAt < $cutoff)
+               | select(.headSha as $s | ($open | index($s)) | not)
+               | .databaseId' \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
 
   cleanup-caches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, r
 
 - **Language**: C# / .NET 10.0 (`global.json` pins SDK `10.0.301`)
 - **Framework**: ASP.NET Core with Dapr.AspNetCore
-- **Infrastructure**: Docker Compose (multi-file), Dapr sidecar, Redis, Jaeger (OTel tracing)
+- **Infrastructure**: Docker Compose (`docker-compose.yaml` + `compose/dapr-docker-compose.yaml`), Dapr sidecar, Redis, Jaeger (OTel tracing)
 - **Solution**: `dapr-docker-csharp.slnx` (.NET 10 XML format)
 - **App project**: `src/queue-processor/`
 - **Test projects**:
@@ -116,12 +116,13 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push to main, tags 
 | **changes** | — | `dorny/paths-filter` short-circuits doc-only changes |
 | **static-check** | changes (code) | `make static-check` (lint + vulncheck + trivy-fs + secrets + mermaid-lint) |
 | **build** | static-check | `make build` |
+| **image-build** | static-check | `make image-build` (build-only Dockerfile validation, no push) |
 | **test** | static-check | `make test` (unit) |
 | **integration-test** | static-check | `make integration-test` (Testcontainers) |
 | **e2e** | build, test | `make e2e` (Docker Compose full-stack) |
 | **ci-pass** | all of the above (always) | Aggregator status check (target for branch protection / Rulesets) |
 
-Permissions: workflow-level `contents: read` + `pull-requests: read` (for `paths-filter`). SDK version from `global.json`. NuGet caching via `packages.lock.json`. mise-action installs `.mise.toml`-pinned tools for the static-check job.
+Permissions: workflow-level `contents: read` + `pull-requests: read` (for `paths-filter`). SDK version from `global.json`. NuGet caching via `packages.lock.json`. mise-action installs `.mise.toml`-pinned tools for every make-running job.
 
 **Toolchain split (documented exception to the "mise-action over `setup-*`" portfolio rule)**: `actions/setup-dotnet@<sha>` is retained alongside `jdx/mise-action` because (a) `global.json`'s `rollForward: latestFeature` is honored at install time by setup-dotnet — mise would require an exact `.mise.toml` pin and lose the rollForward semantics, and (b) setup-dotnet's `cache: true` + `packages.lock.json` is the canonical NuGet cache. mise-action owns the non-.NET surface (Node, pnpm, jq, act, trivy, gitleaks).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | E2E testing | Docker Compose + bash curl harness + Dapr publish API |
 | Container runtime | Docker Compose v2; production multi-stage `src/queue-processor/Dockerfile` (non-root `app:app`, BuildKit-ARG HEALTHCHECK) |
 | Static analysis | `dotnet format`, `dotnet build -warnaserror`, `dotnet list package --vulnerable`, Trivy filesystem scan, gitleaks, mermaid-cli |
-| CI | GitHub Actions (changes → static-check → build/test/integration-test → e2e → ci-pass), `dorny/paths-filter` + `jdx/mise-action` |
+| CI | GitHub Actions (changes → static-check → build/image-build/test/integration-test → e2e → ci-pass), `dorny/paths-filter` + `jdx/mise-action` |
 | Dependency mgmt | Renovate (`automergeType: pr`, squash) — covers NuGet + Dockerfile + docker-compose + GitHub Actions + mise + custom-regex |
 | Version manager | mise (`.mise.toml` pins Node, pnpm, jq, act, trivy, gitleaks) |
 
@@ -180,6 +180,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, `workflow
 | **changes** | every run | `dorny/paths-filter` short-circuits doc-only changes |
 | **static-check** | code change or tag push | `make static-check` (lint + vulncheck + trivy-fs + secrets + mermaid-lint) |
 | **build** | after static-check | `make build` |
+| **image-build** | after static-check | `make image-build` (build-only Dockerfile validation, no push) |
 | **test** | after static-check | `make test` (unit) |
 | **integration-test** | after static-check | `make integration-test` (Testcontainers Redis + daprd) |
 | **e2e** | after build + test | `make e2e` (Docker Compose full-stack roundtrip) |

--- a/renovate.json
+++ b/renovate.json
@@ -127,6 +127,14 @@
       ]
     },
     {
+      "description": "Group runtime infra images (redis, jaeger). `redis` is tracked across TWO managers with different tags — docker-compose (`redis:8`) and the C# Testcontainers fixture custom.regex (`redis:8-alpine`); without one shared branch a major bump collides on the `renovate/redis-*` branch slug and one ref is silently dropped, drifting forever. Grouping forces both refs (plus jaeger) into a single PR.",
+      "groupName": "runtime infra images",
+      "matchPackageNames": [
+        "redis",
+        "jaegertracing/jaeger"
+      ]
+    },
+    {
       "description": "Makefile docker dev-tool pins (mermaid-cli, catthehacker/ubuntu) are interpolated into `docker run image:$(VAR)` recipes with no digest. Suppress docker:pinDigests to avoid a pinDigest x version-bump branch collision.",
       "matchFileNames": [
         "Makefile"


### PR DESCRIPTION
Follow-ups from a `/project-review` pass. All foundation (Phase A) + documentation (Phase B) fixes; LOW/optional items applied where they were clean accuracy improvements.

## Fixes

### CI — `cleanup-runs.yml` (BLOCKING + HIGH)
- **Open-PR run retention:** age-based pruning now excludes the head SHAs of all open PRs, so a slow/idle PR (e.g. a long-pending Renovate PR) never loses the run carrying its required `ci-pass` check — which would otherwise leave it `BLOCKED` with zero reported checks.
- Added `pull-requests: read` permission needed by the new `gh pr list` call.

### Renovate — cross-manager `redis` drift (HIGH)
`redis` was tracked by two managers with different tags: `redis:8` (docker-compose) and `redis:8-alpine` (C# Testcontainers fixture custom.regex). On a major bump both updates target the same `renovate/redis-*` branch slug → collision → one ref silently dropped and drifts forever. Grouping `redis` + `jaegertracing/jaeger` into one **runtime infra images** PR forces a single shared branch. *(Config is currently inert — the Mend Cloud Renovate app has been disabled on this repo since ~2026-03-30; this takes effect on reactivation.)*

### CI — `image-build` validation job (advisory)
Added a build-only `image-build` job (no push — there is no publish workflow). `make ci` and the other jobs never run `docker build`, so the multi-stage Dockerfile was unvalidated by CI: a HEALTHCHECK parse error / COPY-path drift / bad base digest would ship undetected (exactly how the June HEALTHCHECK `--interval=${VAR}` break sat unbuilt). Wired into `ci-pass`.

### Docs (LOW)
- README + CLAUDE.md CI job tables updated for the new `image-build` job.
- CLAUDE.md: name the second compose file (`compose/dapr-docker-compose.yaml`); correct the mise-action scope note (every make-running job, not just static-check).

## Findings reviewed and NOT applied (with rationale)
- **Makefile** `deps` prereqs on interactive helpers (`dapr-*`, `redis-*`) — LOW; the agent assessed acceptable as-is since they presuppose a running stack (`make start`). Adding `deps` would run `mise install` on every helper invocation for no real benefit.
- **README** section ordering of `## Environment Configuration` — INFO; additional sections are permitted, not a canonical-order violation.
- **Test-coverage** 4 LOW edge cases (poison-msg redelivery contract, daprd-own-spans assertion, GET-`/`-when-store-unreachable unit, OTLP-disabled unit) — deferred to `/test-coverage-analysis` Phase 4 (test generation is out of project-review's research-only scope).

## Validation
- `python yaml.safe_load` — ci.yml + cleanup-runs.yml valid.
- `make renovate-validate` — no validationError.
- `make image-build` — builds clean (multi-stage, non-root, HEALTHCHECK valid, multi-arch + attestation).
- `make mermaid-lint` — rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)