### PR TITLE
chore: upgrade tooling + deps (TUnit 1.56.25, checkout v7, mise-action v4.2.0, mise tools)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -61,7 +61,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -89,7 +89,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -118,7 +118,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -140,7 +140,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -162,7 +162,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
@@ -191,7 +191,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/packages.lock.json'
 
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 node = "22"
-pnpm = "11.7.0"
-"aqua:jqlang/jq" = "1.8.1"
+pnpm = "11.8.0"
+"aqua:jqlang/jq" = "1.8.2"
 "aqua:nektos/act" = "0.2.89"
-"aqua:aquasecurity/trivy" = "0.71.1"
+"aqua:aquasecurity/trivy" = "0.71.2"
 "aqua:gitleaks/gitleaks" = "8.30.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,10 @@ Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, r
 Pinned in `.mise.toml` and Renovate-tracked:
 
 - **Node**: 22 (used by Renovate validation)
-- **pnpm**: 11.7.0
-- **jq**: 1.8.1 (`aqua:jqlang/jq`)
+- **pnpm**: 11.8.0
+- **jq**: 1.8.2 (`aqua:jqlang/jq`)
 - **act**: 0.2.89 (`aqua:nektos/act`)
-- **trivy**: 0.71.1 (`aqua:aquasecurity/trivy`)
+- **trivy**: 0.71.2 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
 - **mermaid-cli**: 11.15.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
 - **.NET SDK**: 10.0.301 (from `global.json`)
@@ -102,7 +102,7 @@ Three-layer pyramid — each layer covers a distinct surface and runs as its own
 | Integration | `tests/queue-processor.integration.tests/` | Testcontainers Redis + daprd; real `DaprClient` over HTTP/gRPC | `make integration-test` | `integration-test` |
 | E2E | `e2e/e2e-test.sh` | Full Docker Compose stack: app + daprd + Redis + Jaeger | `make e2e` | `e2e` |
 
-- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.56.0 with Microsoft Testing Platform
+- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.56.25 with Microsoft Testing Platform
 - **Mocking**: FakeItEasy 9.0.1 (per portfolio testing rule)
 - **Integration containers**: `Testcontainers` + `Testcontainers.Redis` 4.12
 - **Run discipline**: `dotnet run --project ...` (required for TUnit on .NET 10 SDK; MTP entry point)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@
 services:
   ## QueueProcessor
   queueprocessor:
-    image: mcr.microsoft.com/dotnet/sdk:10.0@sha256:f061e5a7532b36fa1d1b684857fe1f504ba92115b9934f154643266613c44c62
+    image: mcr.microsoft.com/dotnet/sdk:10.0@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3
     command: ["dotnet", "watch", "run", "--no-hot-reload"]
     working_dir: /app
     volumes:

--- a/tests/queue-processor.integration.tests/packages.lock.json
+++ b/tests/queue-processor.integration.tests/packages.lock.json
@@ -59,15 +59,15 @@
       },
       "TUnit": {
         "type": "Direct",
-        "requested": "[1.56.0, )",
-        "resolved": "1.56.0",
-        "contentHash": "K0Fpy4ubt4zW57xrzFN6rb6ep6ZHMhihbJu5i1zehjgl43bGs8jkt6TNIpQ2I/E1cHqtETrsNmFBL5l3VLMlIw==",
+        "requested": "[1.56.25, )",
+        "resolved": "1.56.25",
+        "contentHash": "C77kGntWeIyL06V3KrVYcxv91zO3ozGJhwai8gGWxFmoPBhN3UXM6aA1aQS2WupjXGbqSlmCxA2DxxEbxtFGCA==",
         "dependencies": {
           "Microsoft.Testing.Extensions.CodeCoverage": "18.8.0",
           "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
           "Microsoft.Testing.Extensions.TrxReport": "2.2.3",
-          "TUnit.Assertions": "1.56.0",
-          "TUnit.Engine": "1.56.0"
+          "TUnit.Assertions": "1.56.25",
+          "TUnit.Engine": "1.56.25"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -671,24 +671,24 @@
       },
       "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "is0HoqC0UBIlD6tEJVm/MqariZT0Y6g+2khjKGLc4y7sFPGIUIF9KEzFcOB+hjLEzXSWJwb34G5bfSYw7qwTOg=="
+        "resolved": "1.56.25",
+        "contentHash": "095wYRPB26Tpc3vHIRq8pElayAYQuY5Patp244X76+hw1lxBiQ/2kBhYeIob51LOH1/Znd/eKGx9gtJLiy4SXQ=="
       },
       "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "LTzkkcbeRu7CdAg9iyuQPWLiSS16HwIePmFqthRAu2Iz9DoaclJeL06SrWjJrEav6qXB9PJUjrweGbWPWOV/UA=="
+        "resolved": "1.56.25",
+        "contentHash": "tVgUL4cJyOR0MVQcUYYDTqRzCLiGEksyBcPbHEQC9mRz4Tfnqkc2x1pMnrEDmkZg0qhc8HK+Jgo5J4ohRoQjXg=="
       },
       "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "O3B3QfaE6UpMSrhQi7H4pj3kePspPfB19BZOklZK2n1blCh93UDT5gXRq6LDwzTycCZyplJIzl1YqfY2pedKMQ==",
+        "resolved": "1.56.25",
+        "contentHash": "i96HdbNEnlAsBY29DE8faIQNjEOlAhUfNxVxDwXrVWP4/Hb79rLygg67F01waXNyFIBmfJI9D2BzNQ4bXBJ8/w==",
         "dependencies": {
           "EnumerableAsyncProcessor": "3.8.4",
           "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
           "Microsoft.Testing.Platform": "2.2.3",
           "Microsoft.Testing.Platform.MSBuild": "2.2.3",
-          "TUnit.Core": "1.56.0"
+          "TUnit.Core": "1.56.25"
         }
       },
       "queue-processor": {

--- a/tests/queue-processor.integration.tests/queue-processor.integration.tests.csproj
+++ b/tests/queue-processor.integration.tests/queue-processor.integration.tests.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="TUnit" Version="1.56.0"/>
+        <PackageReference Include="TUnit" Version="1.56.25"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9"/>
         <PackageReference Include="Testcontainers" Version="4.12.0"/>
         <PackageReference Include="Testcontainers.Redis" Version="4.12.0"/>

--- a/tests/queue-processor.tests/packages.lock.json
+++ b/tests/queue-processor.tests/packages.lock.json
@@ -24,15 +24,15 @@
       },
       "TUnit": {
         "type": "Direct",
-        "requested": "[1.56.0, )",
-        "resolved": "1.56.0",
-        "contentHash": "K0Fpy4ubt4zW57xrzFN6rb6ep6ZHMhihbJu5i1zehjgl43bGs8jkt6TNIpQ2I/E1cHqtETrsNmFBL5l3VLMlIw==",
+        "requested": "[1.56.25, )",
+        "resolved": "1.56.25",
+        "contentHash": "C77kGntWeIyL06V3KrVYcxv91zO3ozGJhwai8gGWxFmoPBhN3UXM6aA1aQS2WupjXGbqSlmCxA2DxxEbxtFGCA==",
         "dependencies": {
           "Microsoft.Testing.Extensions.CodeCoverage": "18.8.0",
           "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
           "Microsoft.Testing.Extensions.TrxReport": "2.2.3",
-          "TUnit.Assertions": "1.56.0",
-          "TUnit.Engine": "1.56.0"
+          "TUnit.Assertions": "1.56.25",
+          "TUnit.Engine": "1.56.25"
         }
       },
       "Castle.Core": {
@@ -585,24 +585,24 @@
       },
       "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "is0HoqC0UBIlD6tEJVm/MqariZT0Y6g+2khjKGLc4y7sFPGIUIF9KEzFcOB+hjLEzXSWJwb34G5bfSYw7qwTOg=="
+        "resolved": "1.56.25",
+        "contentHash": "095wYRPB26Tpc3vHIRq8pElayAYQuY5Patp244X76+hw1lxBiQ/2kBhYeIob51LOH1/Znd/eKGx9gtJLiy4SXQ=="
       },
       "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "LTzkkcbeRu7CdAg9iyuQPWLiSS16HwIePmFqthRAu2Iz9DoaclJeL06SrWjJrEav6qXB9PJUjrweGbWPWOV/UA=="
+        "resolved": "1.56.25",
+        "contentHash": "tVgUL4cJyOR0MVQcUYYDTqRzCLiGEksyBcPbHEQC9mRz4Tfnqkc2x1pMnrEDmkZg0qhc8HK+Jgo5J4ohRoQjXg=="
       },
       "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "1.56.0",
-        "contentHash": "O3B3QfaE6UpMSrhQi7H4pj3kePspPfB19BZOklZK2n1blCh93UDT5gXRq6LDwzTycCZyplJIzl1YqfY2pedKMQ==",
+        "resolved": "1.56.25",
+        "contentHash": "i96HdbNEnlAsBY29DE8faIQNjEOlAhUfNxVxDwXrVWP4/Hb79rLygg67F01waXNyFIBmfJI9D2BzNQ4bXBJ8/w==",
         "dependencies": {
           "EnumerableAsyncProcessor": "3.8.4",
           "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
           "Microsoft.Testing.Platform": "2.2.3",
           "Microsoft.Testing.Platform.MSBuild": "2.2.3",
-          "TUnit.Core": "1.56.0"
+          "TUnit.Core": "1.56.25"
         }
       },
       "queue-processor": {

--- a/tests/queue-processor.tests/queue-processor.tests.csproj
+++ b/tests/queue-processor.tests/queue-processor.tests.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="TUnit" Version="1.56.0"/>
+        <PackageReference Include="TUnit" Version="1.56.25"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9"/>
         <PackageReference Include="FakeItEasy" Version="9.0.1"/>
     </ItemGroup>


### PR DESCRIPTION
`/ship-it` upgrade pass. **Renovate is disabled on this repo** (Mend Cloud app dead since ~2026-03-30), so this is the only path for dependency/tool currency.

## Upgrades applied
| Surface | From → To | Notes |
|---|---|---|
| TUnit (both test projects) | 1.56.0 → 1.56.25 | lock files regenerated; integration 9/9 green |
| pnpm (.mise.toml) | 11.7.0 → 11.8.0 | |
| jq (.mise.toml) | 1.8.1 → 1.8.2 | |
| trivy (.mise.toml) | 0.71.1 → 0.71.2 | static-check scan clean |
| actions/checkout | v6.0.3 → v7.0.0 | major; verified node24 runtime unchanged, internal ESM/security-only changes, drop-in for input-less usage |
| jdx/mise-action | v4.1.0 → v4.2.0 | minor |
| compose dev `sdk:10.0` digest | f061… → 548d… | was stale; now aligned to the Dockerfile build-stage digest |
| CLAUDE.md Tool Versions + Testing | refreshed | matches the bumps |

## Already latest (no change)
.NET SDK 10.0.301, node 22, act 0.2.89, gitleaks 8.30.1, mermaid-cli 11.15.0, daprd 1.18.1, redis:8, jaeger 2.19.0, Dockerfile base digests, all other NuGet (Dapr 1.18.4, OTel 1.16/1.15, Testcontainers 4.12, FakeItEasy 9.0.1, Mvc.Testing 10.0.9), setup-dotnet v5.3.0, paths-filter v4.0.1.

## Verification
- `make ci` green locally: static-check (lint + vulncheck + **trivy 0.71.2** + secrets + mermaid-lint), unit, **integration 9/9** (TUnit 1.56.25 + Testcontainers Redis+daprd), build 0 warnings.
- Workflow YAML valid; all action SHAs 40-hex with version comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)