### PR TITLE
test: cover GET / state-store failure path (returns 500)

### DIFF
--- a/tests/queue-processor.tests/EndpointTests.cs
+++ b/tests/queue-processor.tests/EndpointTests.cs
@@ -43,6 +43,21 @@ public class EndpointTests
     }
 
     [Test]
+    public async Task GetRoot_WhenStateStoreThrows_Returns500()
+    {
+        await using var factory = new QueueProcessorWebFactory();
+        A.CallTo(() => factory.MockDaprClient
+                .GetStateAsync<int>("statestore", "counter", A<ConsistencyMode?>.Ignored, A<IReadOnlyDictionary<string, string>?>.Ignored, A<CancellationToken>.Ignored))
+            .Throws(new Exception("redis down"));
+
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.InternalServerError);
+    }
+
+    [Test]
     public async Task PostCounter_SquaresValue_AndSavesState()
     {
         await using var factory = new QueueProcessorWebFactory();


### PR DESCRIPTION
Closes the one clean LOW test-coverage gap from the project review: the `GET /` handler reads Dapr state but had no failure-mode test, while `POST /counter` already had `PostCounter_WhenStateStoreThrows_Returns500`. This mirrors it — mocks `GetStateAsync` to throw and asserts 500.

Unit suite: 9 → 10 tests, all green locally.

The other three review LOW items are intentionally not pursued: OTLP-disabled is already implicitly covered by every unit test (they all run with no collector), and the two e2e items (poison-redelivery contract, daprd-own-spans) carry flakiness risk for marginal coverage on an already-healthy pyramid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)