### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,8 @@ redis-monitor:
 release:
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		if git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; fi && \
+		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		echo $$newtag > ./version.txt && \
 		git add version.txt && \


### PR DESCRIPTION
Adds local + remote `git` tag pre-existence checks to the `release` recipe before any mutation (version.txt write, `git add`/`commit`) and before the confirm prompt.

**Bug:** the recipe wrote `version.txt`, committed, then ran `git tag` with no existence check. Re-running with an already-used tag landed a dangling "Cut vX release" commit while `git tag` aborted — a half-published release.

Implements Safety Check #16 from the `/makefile` skill.

Verified: `make -n release` parses; feeding an existing tag errors at the guard before any commit, leaving the tree and tags untouched.