### PR TITLE
chore: harden Makefile gates, fix renovate tracking, refresh stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, r
 | `make mermaid-lint` | Validate Mermaid diagrams in Markdown |
 | `make diagrams` | Render C4 PlantUML architecture diagrams (`docs/diagrams/*.puml`) to PNG |
 | `make diagrams-check` | Drift gate: committed PNGs must match current `.puml` source (in `static-check`) |
+| `make diagrams-clean` | Remove rendered diagram artefacts |
 | `make static-check` | Composite quality gate (lint + vulncheck + trivy-fs + secrets + mermaid-lint + diagrams-check) |
 | `make format` | Auto-fix code formatting |
 | `make clean` | Remove build artifacts (bin/obj) |
@@ -85,13 +86,13 @@ Dapr .NET demo application -- a queue processor using Dapr pub/sub with Redis, r
 
 Pinned in `.mise.toml` and Renovate-tracked:
 
-- **Node**: 22 (used by Renovate validation)
-- **pnpm**: 11.8.0
+- **Node**: 24 (used by Renovate validation)
+- **pnpm**: 11.10.0
 - **jq**: 1.8.2 (`aqua:jqlang/jq`)
 - **act**: 0.2.89 (`aqua:nektos/act`)
-- **trivy**: 0.71.2 (`aqua:aquasecurity/trivy`)
+- **trivy**: 0.72.0 (`aqua:aquasecurity/trivy`)
 - **gitleaks**: 8.30.1 (`aqua:gitleaks/gitleaks`)
-- **mermaid-cli**: 11.15.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
+- **mermaid-cli**: 11.16.0 (Docker image `minlag/mermaid-cli`, version constant in Makefile with `# renovate:` annotation)
 - **PlantUML**: renders the C4 architecture diagrams (`docs/diagrams/*.puml`, pinned C4-PlantUML `v2.13.0` `!include`); Docker image `plantuml/plantuml`, `PLANTUML_VERSION` constant in Makefile with `# renovate:` annotation. Renovate `automerge:false` for this dep (its bump needs a manual `make diagrams` PNG regen the bot can't run)
 - **.NET SDK**: 10.0.301 (from `global.json`)
 
@@ -105,9 +106,9 @@ Three-layer pyramid — each layer covers a distinct surface and runs as its own
 | Integration | `tests/queue-processor.integration.tests/` | Testcontainers Redis + daprd; real `DaprClient` over HTTP/gRPC | `make integration-test` | `integration-test` |
 | E2E | `e2e/e2e-test.sh` | Full Docker Compose stack: app + daprd + Redis + Jaeger | `make e2e` | `e2e` |
 
-- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.56.25 with Microsoft Testing Platform
+- **Framework**: [TUnit](https://github.com/thomhurst/TUnit) 1.58.0 with Microsoft Testing Platform
 - **Mocking**: FakeItEasy 9.0.1 (per portfolio testing rule)
-- **Integration containers**: `Testcontainers` + `Testcontainers.Redis` 4.12
+- **Integration containers**: `Testcontainers` + `Testcontainers.Redis` 4.13.0
 - **Run discipline**: `dotnet run --project ...` (required for TUnit on .NET 10 SDK; MTP entry point)
 
 ## CI

--- a/Makefile
+++ b/Makefile
@@ -40,17 +40,28 @@ INTEGRATION_TEST_PROJECT := tests/queue-processor.integration.tests/queue-proces
 # === Docker Compose ===
 DOCKER_COMPOSE := docker compose --file docker-compose.yaml --file compose/dapr-docker-compose.yaml
 
+# Load operator overrides from .env (gitignored) BEFORE the `?=` defaults, so
+# `.env` is authoritative for `make` too — not just for `docker compose` (which
+# auto-loads it). `-include` (leading `-`) silently skips a missing .env, in
+# which case the `?=` defaults apply; a value present in .env sets the var first,
+# so the later `?=` is a no-op. Keep .env shell-clean `KEY=value` (escape `$` as `$$`).
+-include .env
+
 # === Env-driven defaults (mirror .env.example; `?=` lets env override) ===
-HOST_PORT          ?= 5000
-APP_INTERNAL_PORT  ?= 5000
-DAPR_HTTP_PORT     ?= 3500
-PUBSUB_NAME        ?= pubsub
-TOPIC_NAME         ?= counter
-APP_HOST           ?= localhost
-DAPR_HOST          ?= localhost
-HEALTHCHECK_HOST   ?= localhost
-ACT_PORT_MIN       ?= 40000
-ACT_PORT_MAX       ?= 59999
+HOST_PORT                   ?= 5000
+APP_INTERNAL_PORT           ?= 5000
+REDIS_HOST_PORT             ?= 6379
+JAEGER_QUERY_HOST_PORT      ?= 16686
+JAEGER_OTLP_GRPC_HOST_PORT  ?= 4317
+JAEGER_OTLP_HTTP_HOST_PORT  ?= 4318
+DAPR_HTTP_PORT              ?= 3500
+PUBSUB_NAME                 ?= pubsub
+TOPIC_NAME                  ?= counter
+APP_HOST                    ?= localhost
+DAPR_HOST                   ?= localhost
+HEALTHCHECK_HOST            ?= localhost
+ACT_PORT_MIN                ?= 40000
+ACT_PORT_MAX                ?= 59999
 
 # Ensure mise-managed shims are on PATH for tools installed via .mise.toml
 export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
@@ -168,7 +179,7 @@ diagrams: $(DIAGRAM_OUT)
 $(DIAGRAM_DIR)/out/%.png: $(DIAGRAM_DIR)/%.puml $(DIAGRAM_STAMP)
 	@docker image inspect plantuml/plantuml:$(PLANTUML_VERSION) >/dev/null 2>&1 \
 		|| docker pull -q plantuml/plantuml:$(PLANTUML_VERSION) >/dev/null
-	docker run --rm -v "$(CURDIR)/$(DIAGRAM_DIR):/work" -w /work \
+	@docker run --rm -v "$(CURDIR)/$(DIAGRAM_DIR):/work" -w /work \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp -e _JAVA_OPTIONS=-Duser.home=/tmp \
 		plantuml/plantuml:$(PLANTUML_VERSION) \
@@ -181,7 +192,7 @@ $(DIAGRAM_STAMP):
 
 #diagrams-clean: @ Remove rendered diagram artefacts
 diagrams-clean:
-	rm -rf $(DIAGRAM_DIR)/out
+	@rm -rf $(DIAGRAM_DIR)/out
 
 #diagrams-check: @ Verify committed diagram PNGs match current .puml source (CI drift gate)
 diagrams-check: diagrams
@@ -198,8 +209,32 @@ diagrams-check: diagrams
 		echo "$$U"; exit 1; }
 	@echo "diagrams-check: rendered output matches committed source."
 
+#check-env: @ STOPPER gate — fail if the committed .env.example source-of-truth is missing
+check-env:
+	@test -f .env.example || { \
+		echo "ERROR: .env.example is missing (BLOCKING per rules/common/configuration.md)."; \
+		echo "       It is the committed source of truth for every operator-tunable value."; \
+		exit 1; }
+
+#check-ports: @ Fail early if a fixed host port bound by `make start` is already in use
+check-ports:
+	@for pair in "HOST_PORT $(HOST_PORT)" "REDIS_HOST_PORT $(REDIS_HOST_PORT)" \
+			"JAEGER_QUERY_HOST_PORT $(JAEGER_QUERY_HOST_PORT)" \
+			"JAEGER_OTLP_GRPC_HOST_PORT $(JAEGER_OTLP_GRPC_HOST_PORT)" \
+			"JAEGER_OTLP_HTTP_HOST_PORT $(JAEGER_OTLP_HTTP_HOST_PORT)"; do \
+		name=$${pair%% *}; port=$${pair##* }; \
+		if (exec 3<>/dev/tcp/127.0.0.1/$$port) 2>/dev/null; then \
+			exec 3>&- 3<&- 2>/dev/null || true; \
+			holder=$$(docker ps --format '{{.Names}} ({{.Ports}})' 2>/dev/null | grep ":$$port->" || echo "an unknown process"); \
+			echo "ERROR: port $$port ($$name) is already in use by: $$holder"; \
+			echo "       Free it, or override $$name (e.g. 'make start $$name=<free-port>' or set it in .env)."; \
+			exit 1; \
+		fi; \
+	done
+	@echo "check-ports: all fixed host ports free."
+
 #static-check: @ Composite quality gate (lint + vulncheck + trivy-fs + secrets + mermaid-lint + diagrams-check)
-static-check: lint vulncheck trivy-fs secrets mermaid-lint diagrams-check
+static-check: check-env lint vulncheck trivy-fs secrets mermaid-lint diagrams-check
 
 #format: @ Auto-fix code formatting
 format: deps
@@ -224,7 +259,7 @@ ci-run: deps-act
 	ACT_PORT=$$(shuf -i $(ACT_PORT_MIN)-$(ACT_PORT_MAX) -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d); \
 	trap 'rm -rf "$$ARTIFACT_PATH"' EXIT INT TERM; \
-	for j in static-check build test integration-test e2e ci-pass; do \
+	for j in static-check build image-build test integration-test e2e ci-pass; do \
 		echo "==> act job: $$j"; \
 		act push --job "$$j" --container-architecture linux/amd64 --pull=false \
 			-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
@@ -255,7 +290,7 @@ renovate-validate: renovate-bootstrap
 	fi
 
 #start: @ Start Docker Compose services
-start: deps
+start: deps check-ports
 	@$(DOCKER_COMPOSE) up -d
 
 #stop: @ Stop Docker Compose services
@@ -317,7 +352,7 @@ release:
 
 .PHONY: help deps deps-act clean build image-build test integration-test e2e \
 	lint vulncheck trivy-fs secrets mermaid-lint diagrams diagrams-clean diagrams-check \
-	static-check format run ci ci-run \
+	check-env check-ports static-check format run ci ci-run \
 	renovate-bootstrap renovate-validate \
 	start stop restart pull \
 	dapr-logs dapr-pub dapr-counter dapr-get \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Messaging | Dapr pub/sub on Redis Streams |
 | State store | Dapr state on Redis |
 | Tracing | OpenTelemetry → Jaeger via `OpenTelemetry.Extensions.Hosting` 1.16 (OTLP gRPC) |
-| Unit / integration testing | TUnit 1.56 + `WebApplicationFactory` + Testcontainers 4.12 (Redis + daprd) |
+| Unit / integration testing | TUnit 1.58 + `WebApplicationFactory` + Testcontainers 4.13 (Redis + daprd) |
 | Mocking | FakeItEasy 9.0 |
 | E2E testing | Docker Compose + bash curl harness + Dapr publish API |
 | Container runtime | Docker Compose v2; production multi-stage `src/queue-processor/Dockerfile` (non-root `app:app`, BuildKit-ARG HEALTHCHECK) |
@@ -142,6 +142,7 @@ Run `make help` to see all targets.
 | `make mermaid-lint` | Validate Mermaid diagrams in Markdown files |
 | `make diagrams` | Render C4 PlantUML architecture diagrams to PNG |
 | `make diagrams-check` | Verify committed diagram PNGs match their `.puml` source (drift gate) |
+| `make diagrams-clean` | Remove rendered diagram artefacts |
 | `make static-check` | Composite quality gate (lint + vulncheck + trivy-fs + secrets + mermaid-lint + diagrams-check) |
 | `make format` | Auto-fix code formatting |
 | `make clean` | Remove build artifacts |

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "commitMessagePrefix": "chore(all): ",
   "commitMessageAction": "update",
   "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
+  "description": [
+    "platformAutomerge is deliberately false: main's required check is `ci-pass`; platformAutomerge=true would merge in the brief window before the check registers (registration race). Do not flip to true."
+  ],
   "labels": [
     "dependencies"
   ],
@@ -37,6 +40,12 @@
     "**/bin/**",
     "**/obj/**"
   ],
+  "docker-compose": {
+    "description": "Additive pattern: the default docker-compose fileMatch does not match a `dapr-`-prefixed basename, so track the compose/ overlay explicitly (its jaegertracing/jaeger image is referenced nowhere else).",
+    "managerFilePatterns": [
+      "/^compose/.+\\.ya?ml$/"
+    ]
+  },
   "vulnerabilityAlerts": {
     "labels": [
       "security"
@@ -54,7 +63,7 @@
         "scripts/**/*.bash"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z0-9-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z_]+\\s*[:?]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z0-9-]+)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n\\s*[A-Z0-9_]+\\s*[:?]?=\\s*(?<currentValue>[\\w][\\w.+-]*)"
       ]
     },
     {


### PR DESCRIPTION
`/ship-it` health sweep (Stage 2 project review) on the post-diagrams `main`. **Stage 1 upgrade analysis found everything already at latest** — NuGet (Dapr, OpenTelemetry, TUnit, Testcontainers, FakeItEasy), daprd 1.18.1, jaeger 2.19.0, mermaid-cli 11.16.0, plantuml 1.2026.6, .NET SDK 10.0.301, all GitHub Actions SHAs, all mise tools. No upgrades.

## Review fixes applied (5-agent /project-review)

**Makefile**
- `-include .env` — `make` now honours `.env` overrides (compose already did); verified `HOST_PORT=9999` in `.env` reaches `make`.
- `check-env` STOPPER gate (first `static-check` prereq) — proven RED on `.env.example` removal (rc=2), GREEN present.
- `check-ports` preflight on `make start` (HOST_PORT/REDIS_HOST_PORT/JAEGER_*) — proven RED on a bound port, GREEN on free ports.
- `image-build` added to the `ci-run` job loop (was the lone job missing, contradicting the loop's own "every job explicit" note).
- `@`-suppressed the diagrams render + `diagrams-clean` recipes.

**renovate.json**
- **HIGH**: track `compose/dapr-docker-compose.yaml` — `jaegertracing/jaeger` was untracked (default docker-compose fileMatch skips a `dapr-`-prefixed basename; confirmed via renovate dry-run extract).
- Documented `platformAutomerge: false` rationale via top-level `description`.
- Widened Makefile customManager var-name class `[A-Z_]+` → `[A-Z0-9_]+`.

**Docs** — CLAUDE.md + README stale versions corrected to source of truth (Node 24, pnpm 11.10.0, trivy 0.72.0, mermaid-cli 11.16.0, TUnit 1.58.0, Testcontainers 4.13.0); `make diagrams-clean` added to target tables.

## Verification
`make static-check` GREEN (rc=0, zero diagnostics): lint, NuGet vulncheck (no vulnerable ×3), trivy-fs, gitleaks (no leaks), mermaid-lint, diagrams-check, check-env all pass. renovate.json valid JSON.

## Deferred (LOW, reported not applied)
- CI pulls plantuml/mermaid images from Docker Hub anonymously in `static-check` (rate-limit flake risk) — mirror to GHCR or cache as a follow-up.
- `docs/diagrams/**` in the `code` paths-filter also fires the heavy jobs on diagram-only changes — optional scoped-filter optimization (not worth the `if:`-condition risk now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)