### PR TITLE
chore: fix Renovate pinDigests errored branches; correct stale backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,10 +150,6 @@ The Dapr `Configuration` CR (`compose/configuration/configuration.yaml`) wires d
 |---------|---------|
 | `make image-build` | Build the production image (`queue-processor:<git-describe>` + `:latest`) via multi-stage Dockerfile with non-root `app:app` user and HEALTHCHECK |
 
-## Upgrade Backlog
-
-- [ ] **Reactivate Renovate (Mend Cloud GitHub App).** Renovate stopped running on this repo ~2026-03-30 (last bot PR #27; Dependency Dashboard #4 last updated 2026-03-30, still showing pre-`#32` state). Until the app is reinstalled/reauthorized at <https://github.com/apps/renovate> (or the repo's status is fixed at developer.mend.io), dependency automation and `automerge` are dead — every dependency must be bumped manually, and the `renovate.json` config (incl. the mise `minimumReleaseAge` buffer and `platformAutomerge: false` race-fix) is inert. External GitHub-App OAuth action; cannot be done from the repo. Once reactivated, the dashboard reconciles on the first run and the registration-race fix (`platformAutomerge: false`) takes effect.
-
 ## Skills
 
 Use the following skills when working on related files:

--- a/renovate.json
+++ b/renovate.json
@@ -144,9 +144,9 @@
       ]
     },
     {
-      "description": "Makefile docker dev-tool pins (mermaid-cli, catthehacker/ubuntu) are interpolated into `docker run image:$(VAR)` recipes with no digest. Suppress docker:pinDigests to avoid a pinDigest x version-bump branch collision.",
-      "matchFileNames": [
-        "Makefile"
+      "description": "Suppress docker:pinDigests for ALL custom.regex docker pins: the Makefile dev-tool images (mermaid-cli/catthehacker interpolated into `docker run image:$(VAR)`, no digest) AND the C# Testcontainers fixture's tag-only daprd/redis refs. The custom.regex manager cannot write an @sha256 digest onto these, so docker:pinDigests errors the branch forever ('update failure' — the dapr-sidecar + runtime-infra-images pin branches). Scope by manager+datasource (NOT one file) so future custom.regex docker pins are covered too.",
+      "matchManagers": [
+        "custom.regex"
       ],
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
`/renovate` maintenance pass.

## Findings & fixes

**1. Two chronically-Errored Renovate branches (dashboard `## Errored` + `## Repository Problems`)**
- `renovate/dapr-sidecar` — "Pin daprio/daprd Docker tag"
- `renovate/runtime-infra-images` — "Pin dependencies"

Root cause (confirmed by effect): the C# Testcontainers fixture `DaprStateStoreFixture.cs` has **tag-only** `// renovate:` docker refs (`daprio/daprd:1.18.1`, `redis:8-alpine`), and the `pinDigests:false` rule was scoped to `matchFileNames:["Makefile"]` — so `config:best-practices`' `docker:pinDigests` tried to pin the `.cs` refs, which the `custom.regex` manager can't write a digest onto → "update failure" on every run. `LOG_LEVEL=debug renovate --platform=local` showed exactly **2 `isPinDigest:true`** updates (both the fixture refs).

Fix: broaden the rule to `matchManagers:["custom.regex"] + matchDatasources:["docker"]` (covers all custom.regex docker pins, current + future). **Verified by effect: `isPinDigest:true` 2 → 0**, no validationError, daprd/redis remain version-tracked (only digest-pinning suppressed). The Errored branches will self-clear on the next Renovate run.

**2. Stale CLAUDE.md "Reactivate Renovate" backlog item — removed.**
It claimed Renovate stopped ~2026-03-30 (last bot PR #27). **Renovate is active**: `app/renovate` merged PR #57 (pnpm 11.10.0) on 2026-07-08, with #51–#57 all recent bot merges. Per the skill's own rule, bot-PR recency is authoritative over the dashboard's stale state.

## Also verified clean (no change needed)
- `platformAutomerge: false` is CORRECT — `main`'s ruleset requires `ci-pass`, so `false` is the documented registration-race-safe choice (already documented via the top-level `description`).
- The jaeger tracking fix from #59 works — `compose/dapr-docker-compose.yaml (1)` now appears in Detected Dependencies.
- No `dependabot.yml`; `ignorePaths` correctly overrides the default so the `tests/` fixture is tracked; config validates (62 deps across 13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)