### PR TITLE
ci: lint the README Mermaid diagram on README-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       diagrams: ${{ steps.filter.outputs.diagrams }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -54,10 +55,18 @@ jobs:
             # `code || diagrams`; the heavy jobs stay on `code` only.
             diagrams:
               - 'docs/diagrams/**'
+            # README.md carries the inline Mermaid sequence diagram that
+            # `make mermaid-lint` (inside static-check) validates, but it is NOT
+            # in `code` — so a README-only change would otherwise run NO CI and a
+            # broken diagram would merge unlinted. Gate static-check on it too (it
+            # runs the composite gate but skips build/test/e2e). CLAUDE.md is
+            # already in `code`; README.md is the only other Mermaid-bearing doc.
+            docs:
+              - 'README.md'
 
   static-check:
     needs: [changes]
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.diagrams == 'true' || startsWith(github.ref, 'refs/tags/v')
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.diagrams == 'true' || needs.changes.outputs.docs == 'true' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
`README.md` carries an inline Mermaid sequence diagram validated by `make mermaid-lint` (inside `static-check`), but it was in **neither** the `code` nor the `diagrams` paths-filter — so a README-only change ran **no CI**, and a broken Mermaid edit would merge unlinted (red error box on GitHub).

Fix: add a `docs` filter output matching `README.md` and gate `static-check` on `code || diagrams || docs`. A README-only change now runs the composite gate (mermaid-lint + trivy + secrets + …) but still **skips** build/test/integration-test/e2e/image-build — the scoped-filter pattern (§15h refinement option (a)).

Verification: this PR touches `.github/workflows/**` (code) so full CI runs; I'll then confirm with a throwaway README-only probe that only `static-check` runs. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)