### PR TITLE
test: README-only CI probe (DO NOT MERGE — verification only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,5 @@ Only the auto-provided `GITHUB_TOKEN` is used. No additional secrets are require
 A separate cleanup workflow (`.github/workflows/cleanup-runs.yml`) prunes old workflow runs (retains 7 days / minimum 5) and stale branch caches weekly.
 
 [Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with PR automerge (squash strategy) enabled.
+
+<!-- ci-probe: verify README-only change runs mermaid-lint via static-check -->


### PR DESCRIPTION
Throwaway probe: a README-only change should run ONLY static-check (mermaid-lint validates the diagram) + changes + ci-pass, skipping build/test/integration-test/e2e/image-build. Closed after observation.