### PR TITLE
refactor(makefile): standard JAVA_TOOL_OPTIONS for diagram render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ $(DIAGRAM_DIR)/out/%.png: $(DIAGRAM_DIR)/%.puml $(DIAGRAM_STAMP)
 		|| docker pull -q plantuml/plantuml:$(PLANTUML_VERSION) >/dev/null
 	@docker run --rm -v "$(CURDIR)/$(DIAGRAM_DIR):/work" -w /work \
 		--user $$(id -u):$$(id -g) \
-		-e HOME=/tmp -e _JAVA_OPTIONS=-Duser.home=/tmp \
+		-e JAVA_TOOL_OPTIONS=-Duser.home=/tmp \
 		plantuml/plantuml:$(PLANTUML_VERSION) \
 		-tpng -o out $(notdir $<)
 


### PR DESCRIPTION
Converges the `make diagrams` render recipe onto the JVMTI-standard `JAVA_TOOL_OPTIONS=-Duser.home=/tmp`, matching the `/makefile` skill's canonical recipe (previously used the HotSpot-proprietary `_JAVA_OPTIONS` + a no-op `-e HOME=/tmp`).

**Why:** Java derives `user.home` from `getpwuid()`, not `$HOME` — so `-e HOME=/tmp` never fixed the `?/` font-cache litter under `--user`. `JAVA_TOOL_OPTIONS` is the standard env var the JVM honours; the `_JAVA_OPTIONS` form was equivalent but proprietary and diverged from the `/makefile` skill canon (`/architecture-diagrams` reconciled to match in the same session).

**Verification:** forced a full re-render (`rm` stamp + PNGs → `make diagrams`) — output is **byte-identical** (zero PNG drift), env var honoured (`Picked up JAVA_TOOL_OPTIONS`), no `?/` litter.

## Test plan
- [x] Render byte-identical (`git status docs/diagrams/out` empty after re-render)
- [x] No `?/` litter in the mounted tree
- [ ] CI `static-check` (runs `diagrams-check` drift gate) green