### PR TITLE
test: CloudEvent pub/sub delivery coverage + track act-runner image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,15 +150,6 @@ The Dapr `Configuration` CR (`compose/configuration/configuration.yaml`) wires d
 |---------|---------|
 | `make image-build` | Build the production image (`queue-processor:<git-describe>` + `:latest`) via multi-stage Dockerfile with non-root `app:app` user and HEALTHCHECK |
 
-## Upgrade Backlog
-
-Deferred items from `/upgrade-analysis` (2026-07-08). Everything else — NuGet
-packages, .NET SDK (10.0.301, channel-head, LTS to 2028-11-14), all 6 mise
-tools, all 5 Docker images, all 5 CI action SHAs, Dapr 1.18 — is exactly current
-(Renovate-automerge, alive; bot PRs merged 2026-07-08).
-
-- [ ] **`ACT_UBUNTU_VERSION` (`catthehacker/ubuntu:act-latest-20260515`) is Renovate-untracked AND ~6 weeks stale.** The `# renovate:` regex *matches* it, but Renovate drops it at version-resolution: `act-latest-YYYYMMDD` is unorderable under `versioning=loose`, so it never reaches the Dependency Dashboard's Detected Dependencies (only `mermaid-cli` + `plantuml` show under the `regex` manager for the Makefile). Newer tags exist: `act-latest-20260622`, `act-latest-20260629`. **Fix:** change the annotation to `versioning=regex:^act-latest-(?<major>\d{4})(?<minor>\d{2})(?<patch>\d{2})$` (orders the date, excludes `act-latest-dev`) so Renovate can track+bump it — then manually bump the pin to the newest dated tag. Low criticality: this image is used only by the local `make ci-run` (act runner), not shipped or security-facing.
-
 ## Skills
 
 Use the following skills when working on related files:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ PLANTUML_VERSION := 1.2026.6
 # `act-latest-YYYYMMDD` snapshots alongside the floating tag).
 # `versioning=loose` because the suffix isn't semver — Renovate compares
 # tags lexicographically and a later date sorts higher.
-# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
-ACT_UBUNTU_VERSION := act-latest-20260515
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=regex:^act-latest-(?<major>\d{4})(?<minor>\d{2})(?<patch>\d{2})$
+ACT_UBUNTU_VERSION := act-latest-20260629
 
 
 # === Project Paths ===

--- a/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
+++ b/tests/queue-processor.integration.tests/EndpointsIntegrationTests.cs
@@ -104,4 +104,45 @@ public sealed class EndpointsIntegrationTests(DaprStateStoreFixture fixture)
         var stored = await fixture.Client.GetStateAsync<int>(Store, CounterKey);
         await Assert.That(stored).IsEqualTo(123);
     }
+
+    [Test]
+    public async Task CounterTopic_DeliveredAsCloudEvent_IsSquaredAndPersisted()
+    {
+        // The tests above POST a raw int, which bypasses app.UseCloudEvents().
+        // daprd, however, delivers a published `counter` message to the
+        // [Topic("pubsub","counter")] handler as a CloudEvent envelope
+        // (application/cloudevents+json). This exercises that delivery-side
+        // contract end to end: UseCloudEvents unwrapping + the topic route +
+        // a real daprd state save. (The daprd->app HTTP transport itself is
+        // covered by the e2e suite; SubscriptionContractTests covers the
+        // /dapr/subscribe wire that tells daprd to route counter -> /counter.)
+        await fixture.Client.DeleteStateAsync(Store, CounterKey);
+
+        await using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        // Shape mirrors what daprd POSTs for a published `counter` message.
+        var cloudEvent = new
+        {
+            specversion = "1.0",
+            type = "com.dapr.event.sent",
+            source = "queue-processor-it",
+            id = Guid.NewGuid().ToString(),
+            datacontenttype = "application/json",
+            pubsubname = "pubsub",
+            topic = "counter",
+            data = 9,
+        };
+        var content = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(cloudEvent),
+            System.Text.Encoding.UTF8,
+            "application/cloudevents+json");
+        var response = await client.PostAsync("/counter", content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+
+        // 9 squared, unwrapped from the CloudEvent `data` field and persisted.
+        var stored = await fixture.Client.GetStateAsync<int>(Store, CounterKey);
+        await Assert.That(stored).IsEqualTo(81);
+    }
 }


### PR DESCRIPTION
Applies the two follow-ups from this session's `/project-review` + `/upgrade-analysis`.

## 1. Integration test — CloudEvent delivery (closes the LOW test-coverage gap)
Adds `CounterTopic_DeliveredAsCloudEvent_IsSquaredAndPersisted`. The existing integration tests POST a **raw int** to `/counter`, which bypasses `app.UseCloudEvents()`. daprd actually delivers a published `counter` message as an `application/cloudevents+json` **envelope** — so the CloudEvent unwrapping path was untested at integration. The new test POSTs that envelope (data `9`) and asserts the unwrapped value is squared → `81` and persisted via real daprd.

Scope note: the daprd→app HTTP **transport** stays an e2e concern (needs a real app process the sidecar can dial back — the fixture runs the app in-process via WebApplicationFactory, unreachable from the containerized daprd). `SubscriptionContractTests` covers the `/dapr/subscribe` wire; this test covers the delivery-side envelope contract. **Verified: `make integration-test` 10/10.**

## 2. Renovate — track the act-runner image
`ACT_UBUNTU_VERSION` (`catthehacker/ubuntu:act-latest-YYYYMMDD`) was silently **untracked**: `versioning=loose` can't order a date-suffixed tag, so Renovate dropped it at lookup (`invalid-version`) — it never reached Detected Dependencies and drifted ~6 weeks. Switched to `versioning=regex:^act-latest-(?<major>\d{4})(?<minor>\d{2})(?<patch>\d{2})$` and bumped to `act-latest-20260629`. **Verified: `renovate --dry-run=full` now detects it with no `skipReason`.**

CLAUDE.md: dropped the now-resolved Upgrade Backlog item.

## Test plan
- [x] `make integration-test` 10/10
- [x] `make static-check` green (format + build -warnaserror + lint + diagrams + secrets)
- [x] `renovate --dry-run=full` tracks catthehacker/ubuntu
- [ ] CI `ci-pass` green